### PR TITLE
social media info handbook section - initial

### DIFF
--- a/community/social.md
+++ b/community/social.md
@@ -1,3 +1,25 @@
-# pyOpenSci Social Media
+# pyOpenSci Social Media Platforms
+The 2024 North Star for pyOpenSci’s social media accounts is to raise general awareness of pyOpenSci in the broader open source community through both scheduled and ad hoc content that reflects our commitments to diversity and inclusion within the open source scientific Python community. 
 
-more here
+Until 2024, pyOpenSci has had an on and off social media presence since its inception in 2018. Although we’ve previously used Buffer to manage posting across platforms, we currently post directly on each individual site. Our current efforts are localized to [LinkedIn](https://www.linkedin.com/company/pyopensci) and [Fosstodon](https://fosstodon.org/@pyOpenSci) (a Mastodon instance), although we are continuously evaluating other platforms and their compatibility with our community efforts.
+Social Accounts
+
+## Social Accounts
+* **[LinkedIn:](https://www.linkedin.com/company/pyopensci)** LinkedIn is our primary social media platform as of 2024, as it is the place where the majority of the pyOpenSci community can be found. In addition to posting regularly on LinkedIn, we send out a weekly newsletter on LinkedIn that has shown a promising amount of growth its first few weeks of publication.
+* **[Fosstodon:](https://fosstodon.org/@pyOpenSci)** the pyOpenSci Fosstodon account is active, and generally has the same information as what’s posted on our LinkedIn account (albeit in a truncated form). We continue to grow our community on Fosstodon, and intend to keep investing in it as a social media platform.
+* **[Bluesky:](https://bsky.app/profile/pyopensci.bsky.social)** we posted consistently on Bluesky during the first quarter of 2024, however were ineffective at growing a community on the site. We plan to keep the account active with occasional posts, but Bluesky is not a current priority for our social media outreach efforts. 
+* **[X:](https://twitter.com/pyopensci)** although we maintain an account on X, we do not actively post on the platform at this point in time due to both the lack of inclusivity on the platform, as well as community members moving elsewhere. 
+
+## Post types: evergreen vs. *ad hoc* content
+pyOpenSci will run both evergreen content campaigns as well as ad hoc campaigns. One of the major keys to success on social media is publishing on a regular cadence across a series of platforms. Evergreen content allows pyOpenSci to be in constant dialogue on social platforms, in turn generating larger interest in ad hoc posts.
+* Evergreen content is any content that can be prepared well in advance and does not have a timeframe for posting. Examples of evergreen content include:
+    * Volunteer spotlights
+    * Package showcases
+    * Information about pyOpenSci
+    * Python packaging
+* *Ad hoc* content is any content that has a timing element to it, in that the content is only relevant for a specific amount of time. Examples of ad hoc content include:
+    * Calls for volunteers
+    * Live-posting at an event
+    * pyOpenSci content and event launches
+
+It’s important to note that *ad hoc* content can become evergreen content! For example, when the Python Packaging Guide was released, we did a full social media product launch (*ad hoc*), and throughout the year we plan to also spend time highlighting various parts of the guide (evergreen).

--- a/community/social.md
+++ b/community/social.md
@@ -1,5 +1,5 @@
 # pyOpenSci Social Media Platforms
-The 2024 North Star for pyOpenSci’s social media accounts is to raise general awareness of pyOpenSci in the broader open source community through both scheduled and ad hoc content that reflects our commitments to diversity and inclusion within the open source scientific Python community.
+The 2024 North Star for pyOpenSci’s social media accounts is to raise general awareness of pyOpenSci in the broader open source community through both scheduled and ad hoc content that reflects our commitments to diversity and inclusion within the open source scientific Python community. Through these efforts we will also be supporting our mission of empowering scientists to create better software, thereby supporting more open and reproducible science.
 
 Until 2024, pyOpenSci has had an on and off social media presence since its inception in 2018. Although we’ve previously used Buffer to manage posting across platforms, we currently post directly on each individual site. Our current efforts are localized to [LinkedIn](https://www.linkedin.com/company/pyopensci) and [Fosstodon](https://fosstodon.org/@pyOpenSci) (a Mastodon instance), although we are continuously evaluating other platforms and their compatibility with our community efforts.
 Social Accounts

--- a/community/social.md
+++ b/community/social.md
@@ -1,5 +1,5 @@
 # pyOpenSci Social Media Platforms
-The 2024 North Star for pyOpenSci’s social media accounts is to raise general awareness of pyOpenSci in the broader open source community through both scheduled and ad hoc content that reflects our commitments to diversity and inclusion within the open source scientific Python community. 
+The 2024 North Star for pyOpenSci’s social media accounts is to raise general awareness of pyOpenSci in the broader open source community through both scheduled and ad hoc content that reflects our commitments to diversity and inclusion within the open source scientific Python community.
 
 Until 2024, pyOpenSci has had an on and off social media presence since its inception in 2018. Although we’ve previously used Buffer to manage posting across platforms, we currently post directly on each individual site. Our current efforts are localized to [LinkedIn](https://www.linkedin.com/company/pyopensci) and [Fosstodon](https://fosstodon.org/@pyOpenSci) (a Mastodon instance), although we are continuously evaluating other platforms and their compatibility with our community efforts.
 Social Accounts
@@ -7,8 +7,8 @@ Social Accounts
 ## Social Accounts
 * **[LinkedIn:](https://www.linkedin.com/company/pyopensci)** LinkedIn is our primary social media platform as of 2024, as it is the place where the majority of the pyOpenSci community can be found. In addition to posting regularly on LinkedIn, we send out a weekly newsletter on LinkedIn that has shown a promising amount of growth its first few weeks of publication.
 * **[Fosstodon:](https://fosstodon.org/@pyOpenSci)** the pyOpenSci Fosstodon account is active, and generally has the same information as what’s posted on our LinkedIn account (albeit in a truncated form). We continue to grow our community on Fosstodon, and intend to keep investing in it as a social media platform.
-* **[Bluesky:](https://bsky.app/profile/pyopensci.bsky.social)** we posted consistently on Bluesky during the first quarter of 2024, however were ineffective at growing a community on the site. We plan to keep the account active with occasional posts, but Bluesky is not a current priority for our social media outreach efforts. 
-* **[X:](https://twitter.com/pyopensci)** although we maintain an account on X, we do not actively post on the platform at this point in time due to both the lack of inclusivity on the platform, as well as community members moving elsewhere. 
+* **[Bluesky:](https://bsky.app/profile/pyopensci.bsky.social)** we posted consistently on Bluesky during the first quarter of 2024, however were ineffective at growing a community on the site. We plan to keep the account active with occasional posts, but Bluesky is not a current priority for our social media outreach efforts.
+* **[X:](https://twitter.com/pyopensci)** although we maintain an account on X, we do not actively post on the platform at this point in time due to both the lack of inclusivity on the platform, as well as community members moving elsewhere.
 
 ## Post types: evergreen vs. *ad hoc* content
 pyOpenSci will run both evergreen content campaigns as well as ad hoc campaigns. One of the major keys to success on social media is publishing on a regular cadence across a series of platforms. Evergreen content allows pyOpenSci to be in constant dialogue on social platforms, in turn generating larger interest in ad hoc posts.


### PR DESCRIPTION
this is the updated section that contains all of our social media information. note that outward communication (blog, discourse, youtube) and zenodo are considered separate sections, although everything falls under the header of "Community Outreach and Communication", as follows:

# Community Outreach and Communication
* Linktree
* Blog
* Discourse
* YouTube
* Zenodo
* Social media platforms
** Social media accounts
** Content types (ad hoc v. evergreen)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207232741135324