### PR TITLE
Add: sprint process to handbook

### DIFF
--- a/community/events/intro.md
+++ b/community/events/intro.md
@@ -4,28 +4,28 @@
 
 pyOpensci staff regularly attend community meetings (e.g. SciPy meeting, PyCon US, etc). If the meeting is in person, some of the staff may be in person at the event while the community manager / others might be supporting the event remotely.
 
-In these instances asynchronous communication and sharing of documents in an organized way is critical.
+In these instances, asynchronous communication and sharing of documents in an organized way is critical.
 
 ### Event documents
-For every meeting, pyOpenSci staff should create a Google drive folder located in our pyos-shared drive where meeting documents are stored. These documents may include talk and workshop proposals, attendee signup lists, graphics use in social media and out reach posts and more content related to the event.
+For every meeting, pyOpenSci staff should create a Google Drive folder, located in our pyos-shared drive, where meeting documents will be stored. These documents may include talk and workshop proposals, attendee signup lists, graphics used in social media and outreach posts and more content related to the event.
 
 Before an event, pyOpenSci staff will make sure this folder is shared and supporting documents are added to it. Often the folder will be created prior to the event to store talk, Bof (birds of a feather), townhall and workshop proposals.
 
 :::{admonition} Team checkin prior to an event
 :class: note
 
-Staff should also have a short check-in prior to an event to ensure that all documents, and elements needed for the event are shared, in the right place, etc.
+Staff should also have a short check-in prior to an event to ensure that all documents, and elements needed for the event, are shared in the right place, appropriate permissions are granted, remote support needs for the event are clarified, etc.
 
 Because the internet might be an issue sometimes at an event, whomever is leading the event should always bring a pen and paper.
 :::
 
 ## Event social media and graphics
 
-The community manager will manage online “coms” and social media during an event. However it will be important for whomever is attending the event in person to be in asynchronous communication via the pyOpenSci Slack about key activities, findings, new cool things, etc to be posting about, promoting and highlighting.
+The community manager will manage online “comms” and social media during an event. However, it is important for whomever is attending the event in person to be in asynchronous communication via the pyOpenSci Slack about key activities, findings, new cool things, etc. to be posting about, promoting and highlighting.
 
-In some cases an event might “pop up” last minute - such as an Open Space at pyCon. In this case, the person attending the event may want to modify and reuse graphics posted on social media to publicize the event.
+In some cases, an event might “pop up” last minute--such as an Open Space at PyCon. In this case, the person attending the event may want to modify and reuse graphics posted on social media to publicize the event.
 
-To support this case, we should also create an event folder in our online graphics platform, Canva. This event specific folder will be where we store all graphics used to promote an event both before during and after in one place. This will make it easier for the person at the event to make a quick change to a graphic, add a room number or a time for a pop up event or change in plans, as needed.
+To support this case, an event folder in our online graphics platform, Canva, should be created prior to the event and shared with the pyOpenSci team. This event-specific folder will be where all graphics used to promote an event, both before, during and after, are stored. Using Canva as a central location for graphics makes it easier for the person at the event to make a quick change to a graphic, add a room number or a time for a pop up event, notify of any change in plans, etc. as needed.
 
 :::{admonition} Share the Canva folder with the pyopensci-canva-team
 :class: important
@@ -36,17 +36,19 @@ Please also be sure to name files using expressive words that make them easy to 
 
 ### Preparation prior to an event
 
-Prior to an, in-person sprint, you should have the following things created:
+Prior to an in-person sprint, the following items should be created:
 
-1. A template "sign up" form with data fields that we collect from participants. This allows us to track who attends and event and to followup with them after (if they wish to have communication with us after)
+1. A template "sign up" form, created in HubSpot and shared via a bit.ly shortlink, with data fields that we collect from participants. This allows us to track who attends and event and to followup with them after (if they wish to have communication with us after)
 1. A tabletop “card” that says pyOpenSci. You will need 2-3 cards on hand for any event in case participants are spread across a few tables. This card will be important for events like sprints, workshops and open spaces where pyOpenSci has one or more tables in a large room. It will signal to contributors that we are there and help people quickly find us.
- * The card should have a qr code that is dynamic (so we can update the url that it points to and reuse the cards). This will allow us to have participants scan the code using their phones, and add their names as participants in the event. Following the event we can then send a thank message to each participant using a mail-merge system.
+ * The card should have a qr code that is dynamic (so we can update the url that it points to and reuse the cards). This will allow us to have participants scan the code using their phones, and add their names as participants in the event. Following the event we can then send a thank you message to each participant using MailChimp or HubSpot.
 
 :::{todo}
 will this work for events as we will want an event name associated with it but it would be annoying to make a new card for every event? UNLESS we make a bunch at once for all events for the year?
 
-And maybe a banner for a door if I'm running a workshop?
-the table top thing looks like this: https://www.officedepot.com/a/products/5760240/American-Metalcraft-Stainless-Steel-Harp-Style/ (this is better than acrylic because it won't break, but we could do plastic if you prefer).
+We are currently pricing out a travel banner, to be used outside a space where pyOpenSci is running a workshop. 
+An example of the [base/holder for the table top card](https://www.officedepot.com/a/products/5760240/American-Metalcraft-Stainless-Steel-Harp-Style/). We'll initially test out metal, as they will be less likely to break in transit, however acrylic options are also available.
 
-we'd then print out (and laminate?) some kind of card that has the pyOpenSci logo, website, and a QR code that links to all of our socials//mailing list. this way it'll give people a visual cue as to where pyOS is congregating, as well as the option to interact with us directly.
+Cards will be designed and printed, all of which will contain, at minimum, the pyOpenSci logo, website address, and a QR code that links to all of our socials/mailing list. this way it'll give people a visual cue as to where pyOS is congregating, as well as the option to interact with us directly.
+
+Cards will be designed to be printed out on a home printer, or through MOO, and laminated when non-glossy paper is used.
 :::

--- a/community/events/intro.md
+++ b/community/events/intro.md
@@ -25,7 +25,7 @@ The community manager will manage online “coms” and social media during an e
 
 In some cases an event might “pop up” last minute - such as an Open Space at pyCon. In this case, the person attending the event may want to modify and reuse graphics posted on social media to publicize the event.
 
-To support this case, we should also create an event folder in our online graphics platform, Canva (our online graphics platform). This event specific folder will be where we store all graphics used to promote an event both before during and after in one place. This will make it easier for the person at the event to make a quick change to a graphic, add a room number or a time for a pop up event or change in plans, as needed.
+To support this case, we should also create an event folder in our online graphics platform, Canva. This event specific folder will be where we store all graphics used to promote an event both before during and after in one place. This will make it easier for the person at the event to make a quick change to a graphic, add a room number or a time for a pop up event or change in plans, as needed.
 
 :::{admonition} Share the Canva folder with the pyopensci-canva-team
 :class: important
@@ -34,17 +34,13 @@ Be sure to share the Canva folder with the `pyOpensci-canva-team` on Canva to en
 Please also be sure to name files using expressive words that make them easy to find / use / reuse.
 :::
 
-**ADD IMAGE**
-
-Image showing a pycon-24 folders in canva for an event. You can share the entire folder with the team to ensure the team has access to all of the contents inside.
-
 ### Preparation prior to an event
 
-Prior to a, in-person sprint, you should have the following things created:
+Prior to an, in-person sprint, you should have the following things created:
 
 1. A template "sign up" form with data fields that we collect from participants. This allows us to track who attends and event and to followup with them after (if they wish to have communication with us after)
 1. A tabletop “card” that says pyOpenSci. You will need 2-3 cards on hand for any event in case participants are spread across a few tables. This card will be important for events like sprints, workshops and open spaces where pyOpenSci has one or more tables in a large room. It will signal to contributors that we are there and help people quickly find us.
- * The card should have a qr code that is dynamic (so we can update the url that it points to). This will allow us to have participants scan the code using their phones, and add their names as participants in the event. Following the event we can then send a thank message to each participant using a mail-merge system.
+ * The card should have a qr code that is dynamic (so we can update the url that it points to and reuse the cards). This will allow us to have participants scan the code using their phones, and add their names as participants in the event. Following the event we can then send a thank message to each participant using a mail-merge system.
 
 :::{todo}
 will this work for events as we will want an event name associated with it but it would be annoying to make a new card for every event? UNLESS we make a bunch at once for all events for the year?

--- a/community/events/intro.md
+++ b/community/events/intro.md
@@ -45,7 +45,7 @@ Prior to an in-person sprint, the following items should be created:
 :::{todo}
 will this work for events as we will want an event name associated with it but it would be annoying to make a new card for every event? UNLESS we make a bunch at once for all events for the year?
 
-We are currently pricing out a travel banner, to be used outside a space where pyOpenSci is running a workshop. 
+We are currently pricing out a travel banner, to be used outside a space where pyOpenSci is running a workshop.
 An example of the [base/holder for the table top card](https://www.officedepot.com/a/products/5760240/American-Metalcraft-Stainless-Steel-Harp-Style/). We'll initially test out metal, as they will be less likely to break in transit, however acrylic options are also available.
 
 Cards will be designed and printed, all of which will contain, at minimum, the pyOpenSci logo, website address, and a QR code that links to all of our socials/mailing list. this way it'll give people a visual cue as to where pyOS is congregating, as well as the option to interact with us directly.

--- a/community/events/intro.md
+++ b/community/events/intro.md
@@ -1,0 +1,56 @@
+# Meetings & Events
+
+## pyOpenSci meetings
+
+pyOpensci staff regularly attend community meetings (e.g. SciPy meeting, PyCon US, etc). If the meeting is in person, some of the staff may be in person at the event while the community manager / others might be supporting the event remotely.
+
+In these instances asynchronous communication and sharing of documents in an organized way is critical.
+
+### Event documents
+For every meeting, pyOpenSci staff should create a Google drive folder located in our pyos-shared drive where meeting documents are stored. These documents may include talk and workshop proposals, attendee signup lists, graphics use in social media and out reach posts and more content related to the event.
+
+Before an event, pyOpenSci staff will make sure this folder is shared and supporting documents are added to it. Often the folder will be created prior to the event to store talk, Bof (birds of a feather), townhall and workshop proposals.
+
+:::{admonition} Team checkin prior to an event
+:class: note
+
+Staff should also have a short check-in prior to an event to ensure that all documents, and elements needed for the event are shared, in the right place, etc.
+
+Because the internet might be an issue sometimes at an event, whomever is leading the event should always bring a pen and paper.
+:::
+
+## Event social media and graphics
+
+The community manager will manage online “coms” and social media during an event. However it will be important for whomever is attending the event in person to be in asynchronous communication via the pyOpenSci Slack about key activities, findings, new cool things, etc to be posting about, promoting and highlighting.
+
+In some cases an event might “pop up” last minute - such as an Open Space at pyCon. In this case, the person attending the event may want to modify and reuse graphics posted on social media to publicize the event.
+
+To support this case, we should also create an event folder in our online graphics platform, Canva (our online graphics platform). This event specific folder will be where we store all graphics used to promote an event both before during and after in one place. This will make it easier for the person at the event to make a quick change to a graphic, add a room number or a time for a pop up event or change in plans, as needed.
+
+:::{admonition} Share the Canva folder with the pyopensci-canva-team
+:class: important
+
+Be sure to share the Canva folder with the `pyOpensci-canva-team` on Canva to ensure that the entire team has edit access to the graphics and can make last minute changes as needed!
+Please also be sure to name files using expressive words that make them easy to find / use / reuse.
+:::
+
+**ADD IMAGE**
+
+Image showing a pycon-24 folders in canva for an event. You can share the entire folder with the team to ensure the team has access to all of the contents inside.
+
+### Preparation prior to an event
+
+Prior to a, in-person sprint, you should have the following things created:
+
+1. A template "sign up" form with data fields that we collect from participants. This allows us to track who attends and event and to followup with them after (if they wish to have communication with us after)
+1. A tabletop “card” that says pyOpenSci. You will need 2-3 cards on hand for any event in case participants are spread across a few tables. This card will be important for events like sprints, workshops and open spaces where pyOpenSci has one or more tables in a large room. It will signal to contributors that we are there and help people quickly find us.
+ * The card should have a qr code that is dynamic (so we can update the url that it points to). This will allow us to have participants scan the code using their phones, and add their names as participants in the event. Following the event we can then send a thank message to each participant using a mail-merge system.
+
+:::{todo}
+will this work for events as we will want an event name associated with it but it would be annoying to make a new card for every event? UNLESS we make a bunch at once for all events for the year?
+
+And maybe a banner for a door if I'm running a workshop?
+the table top thing looks like this: https://www.officedepot.com/a/products/5760240/American-Metalcraft-Stainless-Steel-Harp-Style/ (this is better than acrylic because it won't break, but we could do plastic if you prefer).
+
+we'd then print out (and laminate?) some kind of card that has the pyOpenSci logo, website, and a QR code that links to all of our socials//mailing list. this way it'll give people a visual cue as to where pyOS is congregating, as well as the option to interact with us directly.
+:::

--- a/community/events/sprints.md
+++ b/community/events/sprints.md
@@ -6,7 +6,7 @@
 
 :::{admonition} TL;DR
 
-**Before sprint**
+**Before a sprint**
 * Go through the pyOPenSci repo issues and ensure all relevant help-wanted / sprintable issues have labels and are on the project board.
 * Also ensure all issues on the project board have enough specific information for a new user to follow and complete the task needed to be done.
 

--- a/community/events/sprints.md
+++ b/community/events/sprints.md
@@ -2,6 +2,17 @@
 
 * TODO: https://github.com/actions/add-to-project?tab=readme-ov-file i think we want to set this up for all repos so this works for scipy.
 
+:::{admonition} TLDR
+* summary here??
+
+During sprint
+
+* label all issues as sprint-event, sprint-name-year
+* merge small pr's that are clearly typo fixies, easy to review things
+* add contributors as contributors to the repo using the all contributors bot @all-contributors add @githubusername for code, review (for an issue use review for a pr use code, review ). Merge each all contributor pr individually and immediately to avoid merge conflicts
+:::
+
+
 ## What is a sprint?
 A sprint is an open session where contributors come together to contribute to an open source project. Contributors may range from beginners, who are new to sprints, GitHub, and git, to experienced developers. Below we review how pyOpenSci runs sprints.
 
@@ -219,12 +230,62 @@ Jesse adds a label for the event and moves it to a column
 If you see small pull requests coming in that are clearly fixing things in a guidebook, please review them and approve if that makes sense. If
 you see an issue opened that makes sense to work on, feel free to comment on it.
 
+## Acknowledge spring contirbutors - All-Contributors Bot
+
+pyOpenSci uses the [All-Contributors bot](https://allcontributors.org/docs/en/bot/usage)
+to recognize and celebrate the contributions of all our contributors. This bot
+helps automate the process of adding contributors to the repository, making it
+easier to maintain accurate records of everyone's efforts.
+
+To add contributors to the repository using the All-Contributors bot:
+
+1. **Use the Bot Command**: In a comment on an issue or pull request, use the following command to add a contributor as follows.
+  `@all-contributors add @githubusername for <contribution types>`
+
+  if they have opened an issue only, or reviewed an open pr use:
+
+  `@all-contributors add @githubusername for review`
+  if they have opened a pull request use:
+  `@all-contributors add @githubusername for code, review`
 
 
-All-contributors bot
-Tagging issues and pr’s with sprint / event name
-Creating a project board for sprint events
-Writing this all up  (let’s test drive for scipy)
+2. **Merge PRs Individually**: The bot will create a pull request to update the
+contributors list. Merge each All-Contributors PR individually and immediately
+to avoid merge conflicts.
+
+By recognizing contributors for their efforts, we foster a positive and inclusive
+community, encouraging more participation and collaboration.
+
+## After a Sprint is complete
+
+After a sprint, we will follow up with participants to show our appreciation
+and encourage continued engagement with the pyOpenSci community. Here are the key
+steps to take:
+
+1. **Send a Thank You Email**: Send an email to all sprint participants thanking them for their contributions. Express gratitude for their time and effort, highlighting any significant achievements or milestones reached during the sprint.
+
+2. **Provide Feedback**: Include any relevant feedback or outcomes from the sprint. This could involve sharing metrics, such as the number of issues closed, pull requests merged, or any specific contributions that stood out.
+
+3. **Invite Continued Engagement**:
+   - **Newsletter**: Encourage participants to subscribe to the pyOpenSci newsletter
+     to stay updated on future events, news, and opportunities.
+   - **LinkedIn**: Invite them to follow pyOpenSci on LinkedIn for professional updates
+     and community highlights.
+   - **GitHub**: Remind them to continue following and contributing to pyOpenSci
+     repositories on GitHub.
+    - Discourse?
+
+4. **Stay Connected**:
+   - **Upcoming Events**: Inform participants about upcoming sprints, webinars,
+     workshops, or any other events they might be interested in.
+
+By taking these steps, you help maintain the momentum generated during the sprint,
+foster a sense of community, and encourage ongoing contributions to pyOpenSci projects.
+
+
+
+
+
 Help for sprint event triage after the event
 Event outputs
 Blog post(s)
@@ -232,12 +293,6 @@ Social
 Welcome new ppl to slack
 Community Content “owners”
 Related to above - help post event. We have a lot of issues and pr’s now. Can the community help with triage?
-
-### After a sprint
-
-* Followup with participants
-* Send out an email thanking people after
-* invite them to stay in touch / follow newsletter / follow linkedin,
 
 
 ## Meeting Metrics that pyOpenSci collects

--- a/community/events/sprints.md
+++ b/community/events/sprints.md
@@ -1,0 +1,264 @@
+# pyOpenSci sprints
+
+* TODO: https://github.com/actions/add-to-project?tab=readme-ov-file i think we want to set this up for all repos so this works for scipy.
+
+## What is a sprint?
+A sprint is an open session where contributors come together to contribute to an open source project. Contributors may range from beginners, who are new to sprints, GitHub, and git, to experienced developers. Below we review how pyOpenSci runs sprints.
+
+There are three types of pyOpenSci sprint events:
+
+1. **Community Sprint Events**: pyOpenSci hosts these at meetings it attends, such as PyCon US and the SciPy meeting.
+2. **Online Sprint Events**: pyOpenSci may hold its own sprint events online to encourage global contributions.
+3. **Community-Hosted Sprint Events**: Contributors and community members host pyOpenSci sprint events at meetings they attend.
+
+During pyOpenSci sprints, contributors need tasks that are “sprintable.”
+Sprintable tasks are those that can be worked on and potentially completed (or
+partially completed) in a single sitting, whether that time is a half-day or a full day.
+
+Sprints can span 1-4 days but are most often 1-2 days long.
+
+### Tracking sprint contributions
+Sprints often result in numerous pull requests and issues being opened by contributors. It’s important for pyOpenSci to track information around:
+
+* who is attending,
+* where they are from (country, state etc) and
+* what contributions they make.
+
+This information will support pyOpenSci's community impact and support and be
+beneficial when we write grants and solicit sponsorships.
+
+#### How we track sprint outcomes
+pyOpenSci tracks issues and pull requests created through community events using project boards. More on project board use is below. We track participation metrics
+using _____ TODO MORE HERE ____
+
+#### pyOpenSci sprints are accessible
+
+It's important to pyOpenSci's mission that sprints are accessible to both new
+and seasoned contributors. We aim to ensure that all participants have a
+successful experience with our community. Some participants are new and are
+submitting their first-ever issue and/or pull request to an open source project.
+These participants may need help using git and GitHub, or they may feel
+intimidated by their first contribution. Others are more experienced and
+comfortable in a sprint environment but may have questions about more technical
+open issues and the outcomes that pyOpenSci wants to see for issue solutions.
+Supporting all of these participants is crucial to our mission and can require
+significant effort during a sprint event.
+
+As such, it's important for anyone leading a sprint to come prepared!
+
+### Sprint Participant Motivations
+
+Sprint participants are often motivated by different things:
+
+* Some come to learn.
+* Some come to help and support a project they care about.
+* Some come to connect and build community.
+
+pyOpenSci supports and empowers all of these motivations, with an emphasis on
+empowering contributors who are newer to contributing while greatly benefiting
+from more experienced sprinters who can help move the organization forward.
+
+
+### Sprint Infrastructure - GitHub Project Boards
+
+To efficiently manage and track contributions during sprints, pyOpenSci utilizes
+GitHub project boards. These boards help us organize tasks that participants can work on. This ensures that
+contributors, whether new or experienced, can easily find and work on tasks
+that suit their skills and interests. They also are used to track new contributions that we get during an event.
+
+#### Help-Wanted Board
+
+The pyOpenSci **Help-Wanted project board** is a organization level GitHub project board that provides a central place where contributors can
+find tasks that pyOpenSci needs help with. We have two automated workflows setup
+for the help-wanted project board:
+
+* Any issue or pull request with the `help-wanted` label is automatically added to this board.
+* When an issue or pull request is closed, it is automatically archived from the project board.
+
+Tasks on this board are ideally smaller, well-defined, and can be completed or significantly advanced within the
+duration of a sprint. The pyOpenSci Help-Wanted board is continuously updated to reflect
+the current needs of pyOpenSci projects, making it easier for contributors to
+jump in and start contributing.
+
+#### Annual Sprint Project Board
+
+At the start of each year, the pyOpenSci community manager creates a new Sprint
+GitHub Project Board. The board will have several columns or statuses each or wchih represents the name of a sprint event (example: pyconus-2024, scipy-2024, fall-festival-2024. This board is used to:
+
+* **Track issues and pull requests opened during a sprint event**
+* **Organize and Monitor Tasks**: Keep track of the progress of tasks during the sprint, ensuring clarity on which issues are being worked on and by whom.
+- **Manage the Triage Process**: Keep track of which pull requests have been addressed and merged and which ones still need attention.
+- **Calculate metrics**: Provide counts of activity that has occurred during a sprint event.
+
+By using these boards, pyOpenSci ensures that sprints are organized, efficient,
+and accessible to all participants.
+
+### Year Round Sprint tasks
+
+Below are tasks to stay on top of throughout the year. By working on
+these items as they pop up, you are saving time spent in preparing for a sprint.
+
+#### Maintain the the pyOpenSci help-wanted project board
+
+pyOpenSci uses the GitHub [help-wanted project board](https://github.com/orgs/pyOpenSci/projects/3)
+to keep track of tasks that volunteers can assist with. When you see an issue
+opened or if you open an issue yourself in any of our GitHub repositories within
+our [pyOpenSci GitHub organization](https://www.github.com/pyopensci), always
+consider whether the issue is something that someone else could help us with.
+
+If the issue is something that someone else in the community could do:
+
+1. **Add a `help-wanted` Label**: Any issue or pull request with the `help-wanted`
+   label in our organization will be automatically added to our [pyOpenSci
+   help-wanted board](https://github.com/orgs/pyOpenSci/projects/3).
+
+2. **Add a `sprintable` Label (if applicable)**: If the task could be completed
+   during a sprint (meaning it is something that could be completed within an
+   hour and up to a single day's worth of work), also add the label `sprintable`
+   to the issue.
+
+3. **Update the Status on the Project Board**: Once the issue has been added to
+   the project board (it normally takes our CI workflow 30 seconds to a minute),
+   update the status of the issue on the project board based on the type of skill
+   needed.
+
+
+The current types of tasks in our board include:
+
+    * Python packaging
+    * Beginner friendly / non technical
+    * Dev Ops / GitHub actions (Continuous Integration)
+    * Python programming
+    * Website - css or ruby
+
+:::{todo}
+we should add content review and sphinx as a status options for people that review our guidebook, run through tutorials etc.
+:::
+
+:::{important}
+If you are creating a new `help-wanted` issue it's critical that you include as much detailed information in the issue as possible. Imagine someone else reading the issue (that is not you!). In reading the issue, does an outside contributor have:
+
+* clearly understand the problem? (be specific, provide examples, links etc)
+* have enough information to solve the problem?
+* know exactly where the problem is occurring (provide links if you can or code examples )
+* have enough information needed to solve the problem?
+
+When in doubt, more information is always better!
+:::
+
+Labeling issues with `help-wanted` / `sprintable` throughout the year as they are opened will save significant preparation time when a Sprint event arises. It will also make it easier for fly-by contributors to find things to help us with throughout the year.
+
+### Pre-Sprint Event Tasks
+
+#### Triage (Help-Wanted) Issues Across the pyOpenSci Organization
+
+Before a sprint begins, someone on the pyOpenSci team should go through and
+triage all of the open issues in the organization to determine:
+
+* Whether some of them are sprintable.
+* Whether they have enough specific and detailed information for someone to work
+  on the issue without too much help during a sprint.
+
+This could be a small team exercise at a pre-meeting event held online for
+pyOpenSci staff and sprint community members (if there are any contributors
+participating).
+
+The information found in the body of an issue is critical to running an effective
+sprint. If the issue has very specific information that gives a potential
+contributor everything they need to know to begin working, they will have fewer
+questions during the sprint. If you have a table of 10-20 people sprinting for
+pyOpenSci, this means the person running the sprint will have less to do on-site!
+Sprints are busy—please add as much specific information as you can to each issue!
+
+#### THIS LIKELY WON'T WORK Ensure issue and pull request templates are up to date
+
+A challenge of a successful sprint is that there will be many issues and pull requests to triage after the sprint. To keep track of new issues and pr's, during an event, every pyOpenSci GitHub repository should have a sprint issue and pull request template. Adding this template only needs to be completed once, however
+if there is a new pyOpenSci Github repository (this rarely happens), make sure that repo has a template.
+
+The sprint template will auto-populate a `sprint-event` label on the issue or pull request when it is opened. We will then setup a workflow on the sprint project board for that year to auto-add any issue or pull request with the `sprint-event` label on it to the sprint project board.
+
+NOTE - i'm not sure this will work. i forgot that pr templates are not as straight forward as issue templates are. issue templates are easier.
+
+### Tasks during a sprint
+
+Below are tasks that should occur during a spring event.
+
+#### Collect participant information
+
+The person running the event should collect information from participants
+at the event via ______ **TODO insert how we do that here** _____.
+
+* dynamic qr code... that people can scan. with small table top signs?
+* what do we collect?
+* how do they opt out of future coms?
+
+
+Metrics –
+Number of pr’s
+Number of issues
+Who contributed
+Where are the contributors from (country, place of work, other things??)
+
+### Update the sprint issue and pull request board
+
+During the event, the remote sprint support team (either community manager or a volunteer) , should
+
+* label all issues and pull requests as `sprint-event` and with the label for the event - e.g. `pyconus-24` as they are opened.
+* Once that the sprint-event label is applied to an issue or pr, they with automatically be added to the project sprint board.
+* Finally, once on the sprint board, they can then move each issue and pull request to the event name status on the sprint board.
+
+This process, if done during the sprint, will make triaging issues and pull requests after the event, easier.
+
+:::{todo}
+We create one issue and pr template that we can use across all our repos  – it has a label that automatically will be added to the board with “no status”
+Jesse adds a label for the event and moves it to a column
+:::
+
+### Review and triage pull requests and issues
+
+If you see small pull requests coming in that are clearly fixing things in a guidebook, please review them and approve if that makes sense. If
+you see an issue opened that makes sense to work on, feel free to comment on it.
+
+
+
+All-contributors bot
+Tagging issues and pr’s with sprint / event name
+Creating a project board for sprint events
+Writing this all up  (let’s test drive for scipy)
+Help for sprint event triage after the event
+Event outputs
+Blog post(s)
+Social
+Welcome new ppl to slack
+Community Content “owners”
+Related to above - help post event. We have a lot of issues and pr’s now. Can the community help with triage?
+
+### After a sprint
+
+* Followup with participants
+* Send out an email thanking people after
+* invite them to stay in touch / follow newsletter / follow linkedin,
+
+
+## Meeting Metrics that pyOpenSci collects
+
+* Number of pr’s
+* Number of issues
+* Who contributed
+    * Where are the contributors from (country, place of work, other things??)
+
+:::{todo}
+SPRINTS: Collecting information during - sprints, etc - process so we can work together?
+GDPR compliant database
+Attendees - where do we keep this info?
+Name
+State / country
+Company / org? (Affiliation)
+Email address
+GH username
+Domain(s) of expertise
+Survey data
+Current role
+Workshops attended
+Social handles
+:::

--- a/community/events/sprints.md
+++ b/community/events/sprints.md
@@ -1,15 +1,23 @@
 # pyOpenSci sprints
 
+:::{todo}
 * TODO: https://github.com/actions/add-to-project?tab=readme-ov-file i think we want to set this up for all repos so this works for scipy.
+:::
 
-:::{admonition} TLDR
-* summary here??
+:::{admonition} TL;DR
 
-During sprint
+**Before sprint**
+* Go through the pyOPenSci repo issues and ensure all relevant help-wanted / sprintable issues have labels and are on the project board.
+* Also ensure all issues on the project board have enough specific information for a new user to follow and complete the task needed to be done.
 
-* label all issues as sprint-event, sprint-name-year
+**During sprint**
+
+* label all newly submitted issues as sprint-event, sprint-name-year
 * merge small pr's that are clearly typo fixies, easy to review things
 * add contributors as contributors to the repo using the all contributors bot @all-contributors add @githubusername for code, review (for an issue use review for a pr use code, review ). Merge each all contributor pr individually and immediately to avoid merge conflicts
+
+**After Sprint**
+
 :::
 
 
@@ -31,18 +39,28 @@ Sprints can span 1-4 days but are most often 1-2 days long.
 ### Tracking sprint contributions
 Sprints often result in numerous pull requests and issues being opened by contributors. It’s important for pyOpenSci to track information around:
 
-* who is attending,
-* where they are from (country, state etc) and
-* what contributions they make.
+* Who is attending,
+* Where they are from (country, state etc) and
+* What contributions they make.
 
 This information will support pyOpenSci's community impact and support and be
 beneficial when we write grants and solicit sponsorships.
 
-#### How we track sprint outcomes
-pyOpenSci tracks issues and pull requests created through community events using project boards. More on project board use is below. We track participation metrics
-using _____ TODO MORE HERE ____
+pyOpenSci uses a combination of GitHub project boards and user surveys to track participation and success metrics. More on that below.
 
-#### pyOpenSci sprints are accessible
+## Sprint Participant Motivations
+
+Sprint participants are often motivated by different things:
+
+* Some come to learn.
+* Some come to help and support a project they care about.
+* Some come to connect and build community.
+
+pyOpenSci supports and empowers all of these motivations, with an emphasis on
+empowering contributors who are newer to contributing while greatly benefiting
+from more experienced sprinters who can help move the organization forward.
+
+### pyOpenSci sprints are accessible
 
 It's important to pyOpenSci's mission that sprints are accessible to both new
 and seasoned contributors. We aim to ensure that all participants have a
@@ -55,22 +73,10 @@ open issues and the outcomes that pyOpenSci wants to see for issue solutions.
 Supporting all of these participants is crucial to our mission and can require
 significant effort during a sprint event.
 
-As such, it's important for anyone leading a sprint to come prepared!
-
-### Sprint Participant Motivations
-
-Sprint participants are often motivated by different things:
-
-* Some come to learn.
-* Some come to help and support a project they care about.
-* Some come to connect and build community.
-
-pyOpenSci supports and empowers all of these motivations, with an emphasis on
-empowering contributors who are newer to contributing while greatly benefiting
-from more experienced sprinters who can help move the organization forward.
+As such, it's important for anyone leading a sprint to come prepared! In some cases having community helpers will go along way to supporting beginner contributor success.
 
 
-### Sprint Infrastructure - GitHub Project Boards
+## Sprint Infrastructure - GitHub Project Boards
 
 To efficiently manage and track contributions during sprints, pyOpenSci utilizes
 GitHub project boards. These boards help us organize tasks that participants can work on. This ensures that
@@ -79,7 +85,7 @@ that suit their skills and interests. They also are used to track new contributi
 
 #### Help-Wanted Board
 
-The pyOpenSci **Help-Wanted project board** is a organization level GitHub project board that provides a central place where contributors can
+The pyOpenSci [**Help-Wanted project board**](https://github.com/orgs/pyOpenSci/projects/3) is a organization level GitHub project board that provides a central place where contributors can
 find tasks that pyOpenSci needs help with. We have two automated workflows setup
 for the help-wanted project board:
 
@@ -87,22 +93,24 @@ for the help-wanted project board:
 * When an issue or pull request is closed, it is automatically archived from the project board.
 
 Tasks on this board are ideally smaller, well-defined, and can be completed or significantly advanced within the
-duration of a sprint. The pyOpenSci Help-Wanted board is continuously updated to reflect
-the current needs of pyOpenSci projects, making it easier for contributors to
-jump in and start contributing.
+duration of a sprint. The pyOpenSci Help-Wanted board should be updated throughout the year as new issues are opened in our organization GitHub repositories. Continual updates makes it easier for:
+
+* Contributors to jump in and start contributing and
+* Sprint leaders to prepare for a sprint as the board will be more up to date.
 
 #### Annual Sprint Project Board
 
 At the start of each year, the pyOpenSci community manager creates a new Sprint
-GitHub Project Board. The board will have several columns or statuses each or wchih represents the name of a sprint event (example: pyconus-2024, scipy-2024, fall-festival-2024. This board is used to:
+GitHub Project Board. Here is an example of the [2024 sprint project board](https://github.com/orgs/pyOpenSci/projects/12).
+
+The board will have several columns or statuses each or which represents the name of a sprint event (example: pyconus-2024, scipy-2024, fall-festival-2024. This board is used to:
 
 * **Track issues and pull requests opened during a sprint event**
 * **Organize and Monitor Tasks**: Keep track of the progress of tasks during the sprint, ensuring clarity on which issues are being worked on and by whom.
 - **Manage the Triage Process**: Keep track of which pull requests have been addressed and merged and which ones still need attention.
 - **Calculate metrics**: Provide counts of activity that has occurred during a sprint event.
 
-By using these boards, pyOpenSci ensures that sprints are organized, efficient,
-and accessible to all participants.
+By using these boards, pyOpenSci staff can easily keep tabs of sprint activities and outcomes. It also helps us ensure that all sprint issues and pull requests are addressed in a timely manner.
 
 ### Year Round Sprint tasks
 
@@ -146,22 +154,23 @@ The current types of tasks in our board include:
 we should add content review and sphinx as a status options for people that review our guidebook, run through tutorials etc.
 :::
 
-:::{important}
-If you are creating a new `help-wanted` issue it's critical that you include as much detailed information in the issue as possible. Imagine someone else reading the issue (that is not you!). In reading the issue, does an outside contributor have:
+:::{admonition} Make sure issues contain specific detailed information before adding them to a project board
+:class: important
 
-* clearly understand the problem? (be specific, provide examples, links etc)
-* have enough information to solve the problem?
-* know exactly where the problem is occurring (provide links if you can or code examples )
-* have enough information needed to solve the problem?
+If you are creating a new `help-wanted` issue, it's important to include as much detailed information in the issue as possible. Imagine someone else reading the issue (that is not you!). In reading the issue, does an outside contributor have:
+
+* enough information to understand the problem? (be specific, provide examples, links runnable code, broken github action runs)
+* enough information to solve the problem?
+* know exactly where the problem is occurring (provide links if you can or code examples)
 
 When in doubt, more information is always better!
 :::
 
 Labeling issues with `help-wanted` / `sprintable` throughout the year as they are opened will save significant preparation time when a Sprint event arises. It will also make it easier for fly-by contributors to find things to help us with throughout the year.
 
-### Pre-Sprint Event Tasks
+## Pre-Sprint Event Tasks
 
-#### Triage (Help-Wanted) Issues Across the pyOpenSci Organization
+### Triage (Help-Wanted) Issues Across the pyOpenSci Organization
 
 Before a sprint begins, someone on the pyOpenSci team should go through and
 triage all of the open issues in the organization to determine:
@@ -169,6 +178,7 @@ triage all of the open issues in the organization to determine:
 * Whether some of them are sprintable.
 * Whether they have enough specific and detailed information for someone to work
   on the issue without too much help during a sprint.
+* Whether some open issues can be closed.
 
 This could be a small team exercise at a pre-meeting event held online for
 pyOpenSci staff and sprint community members (if there are any contributors
@@ -181,23 +191,37 @@ questions during the sprint. If you have a table of 10-20 people sprinting for
 pyOpenSci, this means the person running the sprint will have less to do on-site!
 Sprints are busy—please add as much specific information as you can to each issue!
 
-#### THIS LIKELY WON'T WORK Ensure issue and pull request templates are up to date
+### Ensure issue and pull request templates are up to date
 
-A challenge of a successful sprint is that there will be many issues and pull requests to triage after the sprint. To keep track of new issues and pr's, during an event, every pyOpenSci GitHub repository should have a sprint issue and pull request template. Adding this template only needs to be completed once, however
-if there is a new pyOpenSci Github repository (this rarely happens), make sure that repo has a template.
+A challenge of a successful sprint is that there will be many issues and pull requests to triage after the sprint. To keep track of new issues, during an event, every pyOpenSci GitHub repository should have a sprint issue template. Adding this template only needs to be completed once. However, if there is a new pyOpenSci Github repository (this rarely happens), make sure that repo has a sprint issue template.
 
-The sprint template will auto-populate a `sprint-event` label on the issue or pull request when it is opened. We will then setup a workflow on the sprint project board for that year to auto-add any issue or pull request with the `sprint-event` label on it to the sprint project board.
+The sprint template will auto-populate a `sprint-event` label on the issue or pull request when it is opened. We will then setup a GitHub action on the sprint project board for that year to auto-add any issue or pull request with the `sprint-event` label on it to the sprint project board.
 
+:::{todo}
+test this workflow: https://github.com/actions/add-to-project in a single repo
 NOTE - i'm not sure this will work. i forgot that pr templates are not as straight forward as issue templates are. issue templates are easier.
+:::
 
-### Tasks during a sprint
+### Create a participant signup form
+
+* create the form
+* create a dynamic qr code that we can update (the is placed on our table top cards ) OR get a card that we can add a sticker to with the code and replace the stickers...
+
+
+:::{todo}
+
+jesse will develop this process with whatever platform we end up using...
+:::
+
+
+## Tasks during a sprint
 
 Below are tasks that should occur during a spring event.
 
-#### Collect participant information
+### Collect participant information
 
 The person running the event should collect information from participants
-at the event via ______ **TODO insert how we do that here** _____.
+at the event via ______ **TODO insert how we do that here** _____ following the process Jesse creates above....
 
 * dynamic qr code... that people can scan. with small table top signs?
 * what do we collect?
@@ -212,11 +236,11 @@ Where are the contributors from (country, place of work, other things??)
 
 ### Update the sprint issue and pull request board
 
-During the event, the remote sprint support team (either community manager or a volunteer) , should
+During the event, the remote sprint support team (either Community Manager or a volunteer), should:
 
 * label all issues and pull requests as `sprint-event` and with the label for the event - e.g. `pyconus-24` as they are opened.
-* Once that the sprint-event label is applied to an issue or pr, they with automatically be added to the project sprint board.
-* Finally, once on the sprint board, they can then move each issue and pull request to the event name status on the sprint board.
+* Once that the `sprint-event` label is applied to an issue or pr, they with automatically be added to the project sprint board.
+* Finally, once on the sprint board, they can then move each issue and pull request to the event name status on the sprint board. (this also can be done from the issue itself. )
 
 This process, if done during the sprint, will make triaging issues and pull requests after the event, easier.
 
@@ -227,10 +251,14 @@ Jesse adds a label for the event and moves it to a column
 
 ### Review and triage pull requests and issues
 
-If you see small pull requests coming in that are clearly fixing things in a guidebook, please review them and approve if that makes sense. If
-you see an issue opened that makes sense to work on, feel free to comment on it.
+If you see small pull requests coming in that are clearly fixing things (typos, etc) in a guidebook, please review them and approve if that makes sense.  If
+you see an issue opened that makes sense to work on remotely with a participant, feel free to comment on it.
 
-## Acknowledge spring contirbutors - All-Contributors Bot
+:::{todo}
+We will need to feel some of this out at scipy.
+:::
+
+### Acknowledge sprint contributors - All-Contributors Bot
 
 pyOpenSci uses the [All-Contributors bot](https://allcontributors.org/docs/en/bot/usage)
 to recognize and celebrate the contributions of all our contributors. This bot
@@ -239,24 +267,39 @@ easier to maintain accurate records of everyone's efforts.
 
 To add contributors to the repository using the All-Contributors bot:
 
-1. **Use the Bot Command**: In a comment on an issue or pull request, use the following command to add a contributor as follows.
+**Use the Bot Command**: In a comment on an issue or pull request, use the following command to add a contributor as follows.
+
   `@all-contributors add @githubusername for <contribution types>`
 
-  if they have opened an issue only, or reviewed an open pr use:
+If they have opened an issue only, or reviewed an open pr use:
 
   `@all-contributors add @githubusername for review`
-  if they have opened a pull request use:
+
+If they have opened a pull request use:
   `@all-contributors add @githubusername for code, review`
 
 
-2. **Merge PRs Individually**: The bot will create a pull request to update the
-contributors list. Merge each All-Contributors PR individually and immediately
-to avoid merge conflicts.
+2. **Merge all-contributor bot Pull Requests Individually**: The bot will create a pull request to update the
+contributors list when you call the commands above. IMPORTANT: Merge each all-Contributors bot pull request individually and immediately before adding another contributor to avoid merge conflicts.
 
 By recognizing contributors for their efforts, we foster a positive and inclusive
 community, encouraging more participation and collaboration.
 
-## After a Sprint is complete
+## After a Sprint tasks
+
+### Issue and PR triage
+The biggest effort after a sprint will be triaging & addressing issues and pull requests that have been submitted during the sprint. This could take 1-2 weeks and up to a month depending on the scope of each change submitted.
+
+If there are new issues with no associated pull request, you can
+
+1. Invite the issue author to submit a pr if the change seems reasonable and they are up to the task.
+2. If the issue is one that we agree should be addressed, then label the issue with `help-wanted` / `sprintable`  so someone else can tackle it at our next pyOpenSci sprint.
+
+Review each pull request submitted (or invite community members to review) and determine if the pull request looks good as is or requires changes following the standard GitHub review process.
+
+Merge the pull request when it is complete and ready to be merged.
+
+### Followup thank you notes
 
 After a sprint, we will follow up with participants to show our appreciation
 and encourage continued engagement with the pyOpenSci community. Here are the key
@@ -279,8 +322,8 @@ steps to take:
    - **Upcoming Events**: Inform participants about upcoming sprints, webinars,
      workshops, or any other events they might be interested in.
 
-By taking these steps, you help maintain the momentum generated during the sprint,
-foster a sense of community, and encourage ongoing contributions to pyOpenSci projects.
+By thanking contributors you are helping to maintain the momentum generated during the sprint while also
+fostering a sense of community, and encourage ongoing contributions to pyOpenSci projects.
 
 
 
@@ -295,12 +338,15 @@ Community Content “owners”
 Related to above - help post event. We have a lot of issues and pr’s now. Can the community help with triage?
 
 
-## Meeting Metrics that pyOpenSci collects
 
-* Number of pr’s
-* Number of issues
-* Who contributed
+:::{admonition} Meeting metrics that pyOpenSci collects
+:class: info
+* Number of pull request submitted
+* Number of issues submitted
+* Number of contributors contributed
     * Where are the contributors from (country, place of work, other things??)
+:::
+
 
 :::{todo}
 SPRINTS: Collecting information during - sprints, etc - process so we can work together?

--- a/community/events/sprints.md
+++ b/community/events/sprints.md
@@ -341,7 +341,9 @@ steps to take:
      and community highlights.
    - **GitHub**: Remind them to continue following and contributing to pyOpenSci
      [repositories on GitHub](https://github.com/pyopensci).
+:::{todo}
     - Discourse?
+:::
 
 4. **Stay Connected**:
    - **Upcoming Events**: Inform participants about upcoming sprints, webinars,
@@ -350,26 +352,29 @@ steps to take:
 By thanking contributors you are helping to maintain the momentum generated during the sprint, while also
 fostering a sense of community, and encourage ongoing contributions to pyOpenSci projects.
 
+### Final wrap up activities
 
+We will have several outcome tasks to do to wrap up a sprint. These
+are listed below:
 
+* Blog post about the event with stats around activity (number of participants, pull requests, issues, etc). This post might highlight wins both big and "small"!
+* Social media promoting the success of the event and above metrics
+* LinkedIn newsletter reusing that blog post content
 
+### Welcome new contributors to slack
 
-Help for sprint event triage after the event
-Event outputs
-Blog post(s)
-Social
-Welcome new ppl to slack
-Community Content “owners”
-Related to above - help post event. We have a lot of issues and pr’s now. Can the community help with triage?
-
-
+Because some participants come to sprints to learn, they may not stage engaged with pyOpenSci after a sprint event. As such it's best to invite
+people who continue to stay engaged with us either via GitHub or some
+other mechanism (becoming a reviewer, editor, submitting a package, etc).
 
 :::{admonition} Meeting metrics that pyOpenSci collects
 :class: info
 * Number of pull request submitted
 * Number of issues submitted
 * Number of contributors contributed
-    * Where are the contributors from (country, place of work, other things??)
+    * Where are the contributors from (country, place of work / organization)
+    * Type of user - student, professional, non profit/ public sector.
+    * Optional - demographics
 :::
 
 

--- a/community/events/sprints.md
+++ b/community/events/sprints.md
@@ -1,4 +1,4 @@
-# pyOpenSci sprints
+# pyOpenSci Sprints
 
 :::{todo}
 * TODO: https://github.com/actions/add-to-project?tab=readme-ov-file i think we want to set this up for all repos so this works for scipy.
@@ -7,19 +7,24 @@
 :::{admonition} TL;DR
 
 **Before a sprint**
-* Go through the pyOPenSci repo issues and ensure all relevant help-wanted / sprintable issues have labels and are on the project board.
-* Also ensure all issues on the project board have enough specific information for a new user to follow and complete the task needed to be done.
+
+* pyOpenSci staff go through the pyOpenSci repo issues and ensure all relevant **help-wanted** and/or **sprintable**  both have appropriated labels and have been added to the the project board in the appropriate column (beginner-friendly, python, dev-ops/ci, Python, Sphinx).
+* pyOpenSci staff ensure all issues on the project board have enough **specific** information for a new user to follow and complete the task needed to be done. The more specific the issue is, the fewer questions a sprinter / contributor will ask during a sprint. This saves significant time and energy for both the sprint attendee and whomever is leading the sprint.
 
 **During a sprint**
 
-* label all newly submitted issues as sprint-event, sprint-name-year
-* merge small PRs that are clearly typo fixes and other easy to review things
-* for PRs, add contributors to the repo using the all contributors bot, with the format `@all-contributors add @githubusername for code, review` 
-* for an issue use review for a pr use code, review ). 
-* merge each all contributor PR individually and immediately to avoid merge conflicts
+* Label all newly submitted issues as `sprint-event`, `sprint-name-year` (example: `sprint`, `pyconus-24`)
+* Merge small PRs that are clearly mergeable without significant review. Examples might include: typo fixes and other easy-to- review contributions.
+* For PRs, add contributors to the GitHub repository that they contributed to using the [All Contributors bot](https://allcontributors.org/) using the command: `@all-contributors add @githubusername for code, review` (if the contribution is a pull request) or  `@all-contributors add @githubusername for review` (if the contribution is an issue
+* **IMPORTANT:** Merge each all-contributor-bot PR's individually and immediately after they have been opened to avoid merge conflicts
 
-**After a Sprint**
+**After a sprint**
 
+* Triage issues and pull requests
+* Make sure all contributors have been added to each repo they've contributed to using the all-contributors bot.
+* Focus on replying, addressing and merging pull requests as we can. If an issue has a lingering TODO - consider tagging it with a `help-wanted` label for a future sprint.
+* Send followup *thank you for participating* notes
+* Collect / process / aggregate sprint metrics
 :::
 
 
@@ -50,7 +55,7 @@ beneficial when we write grants and solicit sponsorships.
 
 pyOpenSci uses a combination of GitHub project boards and user surveys to track participation and success metrics. More on that below.
 
-## Sprint Participant Motivations
+## What motivates sprint participants?
 
 Sprint participants are often motivated by different things. Some come to:
 
@@ -58,9 +63,11 @@ Sprint participants are often motivated by different things. Some come to:
 * help and support a project they care about
 * connect and build community
 
-pyOpenSci supports and empowers all of these motivations, with an emphasis on
-empowering contributors who are newer to contributing, while greatly benefiting
-from more experienced sprinters who can help move the organization forward.
+pyOpenSci supports and empowers all of the above motivations. We thrive on empowering new
+empowering contributors to make their first (or second) contributions! This impact aligns well with our mission. We also greatly benefit
+from more experienced sprinters who can help move the organization's infrastructure and needs forward.
+
+Sprints are always a win/win for pyOpenSci.
 
 ### pyOpenSci sprints are accessible
 
@@ -68,26 +75,35 @@ It's important to pyOpenSci's mission that sprints are accessible to both new
 and seasoned contributors. We aim to ensure that all participants have a
 successful experience with our community. Some participants are new and are
 submitting their first-ever issue and/or pull request to an open source project.
-These participants may need help using git and GitHub, or they may feel
-intimidated by their first contribution. Others are more experienced and
+These participants:
+
+* may need help using git and GitHub, or
+* they may feel intimidated by their first contribution (but they want to try!).
+
+Others are more experienced and
 comfortable in a sprint environment but may have questions about more technical
-open issues and the outcomes that pyOpenSci wants to see for issue solutions.
+open issues and the outcomes that pyOpenSci wants to see in issue solutions.
 Supporting all of these participants is crucial to our mission and can require
 significant effort during a sprint event.
 
-As such, it's important for anyone leading a sprint to come prepared! In some cases having community helpers will go along way to supporting beginner contributor success.
+As such, it's important for anyone leading a sprint to come prepared! In most cases having community helpers will go along way to supporting beginner contributor success.
 
-
-## Sprint Infrastructure - GitHub Project Boards
+## Sprint infrastructure - GitHub projects
 
 To efficiently manage and track contributions during sprints, pyOpenSci utilizes
-GitHub project boards. These boards help us organize tasks that participants can work on. This ensures that
+[GitHub projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects). We use projects to organize issues and pull requests that contributors could potentially address during or outside of a sprint. Tasks that are discrete enough to complete during a sprint are labeled with the `sprintable` label.
+
+An organized project ensures that
 contributors, whether new or experienced, can easily find and work on tasks
-that suit their skills and interests. They also are used to track new contributions that we get during an event.
+that suit their skills and interests.
 
-#### Help-Wanted Board
+:::{not}
+We also are testing out using [event projects](https://github.com/orgs/pyOpenSci/projects/12) to to track new contributions in the form of pull requests and issues that we receive during an event such as a PyCon US or SciPy sprint.
+:::
 
-The pyOpenSci [**Help-Wanted project board**](https://github.com/orgs/pyOpenSci/projects/3) is an organization-level GitHub project board that provides a central place where contributors can
+#### Help-wanted board
+
+The pyOpenSci [**help-wanted project board**](https://github.com/orgs/pyOpenSci/projects/3) is an organization-level GitHub project board that provides a central place where contributors can
 find tasks that pyOpenSci needs help with. We have two automated workflows setup
 for the help-wanted project board:
 
@@ -95,12 +111,12 @@ for the help-wanted project board:
 * When an issue or pull request is closed, it is automatically archived from the project board.
 
 Tasks on this board are ideally smaller, well-defined, and can be completed or significantly advanced within the
-duration of a sprint. The pyOpenSci Help-Wanted board should be updated throughout the year as new issues are opened in our organization GitHub repositories. Continual updates makes it easier for:
+duration of a sprint. The pyOpenSci help-wanted board should be updated throughout the year as new issues are opened in our organization GitHub repositories. Continual updates makes it easier for:
 
 * Contributors to jump in and start contributing and
 * Sprint leaders to prepare for a sprint as the board will be more up to date.
 
-#### Annual Sprint Project Board
+#### Tracking annual contributions: the sprint project board
 
 At the start of each year, the pyOpenSci community manager creates a new Sprint
 GitHub Project Board. Here is an example of the [2024 sprint project board](https://github.com/orgs/pyOpenSci/projects/12).
@@ -114,12 +130,12 @@ The board will have several columns or statuses, each of which represents the na
 
 By using these boards, pyOpenSci staff can easily keep tabs of sprint activities and outcomes. It also helps us ensure that all sprint issues and pull requests are addressed in a timely manner.
 
-### Year Round Sprint tasks
+### Year round sprint tasks
 
 Below are tasks to stay on top of throughout the year. By working on
 these items as they pop up, you are saving time spent in preparing for a sprint.
 
-#### Maintain the the pyOpenSci help-wanted project board
+#### Maintain the pyOpenSci help-wanted project board
 
 pyOpenSci uses the GitHub [help-wanted project board](https://github.com/orgs/pyOpenSci/projects/3)
 to keep track of tasks that volunteers can assist with. When you see an issue
@@ -168,11 +184,11 @@ If you are creating a new `help-wanted` issue, it's important to include as much
 When in doubt, more information is always better!
 :::
 
-Labeling issues with `help-wanted` / `sprintable` throughout the year as they are opened will save significant preparation time when a sprint event arises. It will also make it easier for fly-by contributors to find things to help us with throughout the year.
+It is important to label issues with `help-wanted` / `sprintable` throughout the year and as they are opened as we can. This will save significant when preparing for a sprint. It will also make it easier for fly-by contributors to find things to help us with throughout the year.
 
-## Pre-Sprint Event Tasks
+## Pre-sprint tasks
 
-### Triage (Help-Wanted) Issues Across the pyOpenSci Organization
+### Triage (help-wanted) issues across the pyOpenSci organization
 
 Before a sprint begins, someone on the pyOpenSci team should go through and
 triage all of the open issues in the organization to determine:
@@ -200,17 +216,21 @@ One challenge of a successful sprint is that there will be many issues and pull 
 The sprint template will auto-populate a `sprint-event` label on the issue or pull request when it is opened. We will then setup a GitHub action on the sprint project board for that year to auto-add any issue or pull request with the `sprint-event` label on it to the sprint project board.
 
 :::{todo}
-test this workflow: https://github.com/actions/add-to-project in a single repo
-NOTE - i'm not sure this will work. i forgot that pr templates are not as straight forward as issue templates are. issue templates are easier.
+NOTE: i have setup this workflow https://github.com/actions/add-to-project on most (but not all) of our repos now. so it does handle moving help-wanted issues to the project. BUT it is hard to think about events. This is because there is no easy to use pull request template. so while we could automagically update a workflow before an event we'd have to do it for every event AND it would only work on issues - not pull requests. As such my idea of automating event tags won't work.
+
+For now - we should do that manually during the event. It would be an easy enough thing for jesse to do remotely i think? or i could do it IF the sprint slows down. it really didn't at pycon this year (2024)
 :::
+
+
+
+:::{todo}
+
+Jesse will flesh this out when it's ready!
 
 ### Create a participant signup form
 
 * create the form
 * create a dynamic qr code that we can update (the is placed on our table top cards ) OR get a card that we can add a sticker to with the code and replace the stickers...
-
-
-:::{todo}
 
 jesse will develop this process with whatever platform we end up using...
 :::
@@ -222,6 +242,8 @@ Below are tasks that should occur during a sprint event.
 
 ### Collect participant information
 
+*This section will be fleshed out soon...*
+:::{todo}
 The person running the event should collect information from participants
 at the event via ______ **TODO insert how we do that here** _____ following the process Jesse creates above....
 
@@ -229,12 +251,13 @@ at the event via ______ **TODO insert how we do that here** _____ following the 
 * what do we collect?
 * how do they opt out of future coms?
 
-
-Metrics –
+What Metrics do we collect and how?
 Number of PRs
 Number of issues
 Who contributed
 Where are the contributors from (country, place of work, other things??)
+
+:::
 
 ### Update the sprint issue and pull request board
 
@@ -247,7 +270,7 @@ During the event, the remote sprint support team (either Community Manager or a 
 This process, if done during the sprint, will make triaging issues and pull requests after the event, easier.
 
 :::{todo}
-We create one issue and pr template that we can use across all our repos  – it has a label that automatically will be added to the board with “no status”
+We create one issue and pull requesttemplate that we can use across all our repos  – it has a label that automatically will be added to the board with “no status”
 Jesse adds a label for the event and moves it to a column
 :::
 
@@ -273,7 +296,7 @@ To add contributors to the repository using the All-Contributors bot:
 
   `@all-contributors add @githubusername for <contribution types>`
 
-If they have opened an issue only, or reviewed an open pr use:
+If they have opened an issue only, or reviewed an open pull request use:
 
   `@all-contributors add @githubusername for review`
 
@@ -287,7 +310,7 @@ contributors list when you call the commands above. IMPORTANT: Merge each all-Co
 By recognizing contributors for their efforts, we foster a positive and inclusive
 community, encouraging more participation and collaboration.
 
-## After a Sprint tasks
+## After a sprint tasks
 
 ### Issue and PR triage
 The biggest effort after a sprint will be triaging & addressing issues and pull requests that have been submitted during the sprint. This could take 1-2 weeks and up to a month depending on the scope of each change submitted.

--- a/community/events/sprints.md
+++ b/community/events/sprints.md
@@ -10,13 +10,15 @@
 * Go through the pyOPenSci repo issues and ensure all relevant help-wanted / sprintable issues have labels and are on the project board.
 * Also ensure all issues on the project board have enough specific information for a new user to follow and complete the task needed to be done.
 
-**During sprint**
+**During a sprint**
 
 * label all newly submitted issues as sprint-event, sprint-name-year
-* merge small pr's that are clearly typo fixies, easy to review things
-* add contributors as contributors to the repo using the all contributors bot @all-contributors add @githubusername for code, review (for an issue use review for a pr use code, review ). Merge each all contributor pr individually and immediately to avoid merge conflicts
+* merge small PRs that are clearly typo fixes and other easy to review things
+* for PRs, add contributors to the repo using the all contributors bot, with the format `@all-contributors add @githubusername for code, review` 
+* for an issue use review for a pr use code, review ). 
+* merge each all contributor PR individually and immediately to avoid merge conflicts
 
-**After Sprint**
+**After a Sprint**
 
 :::
 
@@ -28,7 +30,7 @@ There are three types of pyOpenSci sprint events:
 
 1. **Community Sprint Events**: pyOpenSci hosts these at meetings it attends, such as PyCon US and the SciPy meeting.
 2. **Online Sprint Events**: pyOpenSci may hold its own sprint events online to encourage global contributions.
-3. **Community-Hosted Sprint Events**: Contributors and community members host pyOpenSci sprint events at meetings they attend.
+3. **Community-hosted Sprint Events**: Contributors and community members host pyOpenSci sprint events at meetings they attend.
 
 During pyOpenSci sprints, contributors need tasks that are “sprintable.”
 Sprintable tasks are those that can be worked on and potentially completed (or
@@ -50,14 +52,14 @@ pyOpenSci uses a combination of GitHub project boards and user surveys to track 
 
 ## Sprint Participant Motivations
 
-Sprint participants are often motivated by different things:
+Sprint participants are often motivated by different things. Some come to:
 
-* Some come to learn.
-* Some come to help and support a project they care about.
-* Some come to connect and build community.
+* learn
+* help and support a project they care about
+* connect and build community
 
 pyOpenSci supports and empowers all of these motivations, with an emphasis on
-empowering contributors who are newer to contributing while greatly benefiting
+empowering contributors who are newer to contributing, while greatly benefiting
 from more experienced sprinters who can help move the organization forward.
 
 ### pyOpenSci sprints are accessible
@@ -85,7 +87,7 @@ that suit their skills and interests. They also are used to track new contributi
 
 #### Help-Wanted Board
 
-The pyOpenSci [**Help-Wanted project board**](https://github.com/orgs/pyOpenSci/projects/3) is a organization level GitHub project board that provides a central place where contributors can
+The pyOpenSci [**Help-Wanted project board**](https://github.com/orgs/pyOpenSci/projects/3) is an organization-level GitHub project board that provides a central place where contributors can
 find tasks that pyOpenSci needs help with. We have two automated workflows setup
 for the help-wanted project board:
 
@@ -103,7 +105,7 @@ duration of a sprint. The pyOpenSci Help-Wanted board should be updated througho
 At the start of each year, the pyOpenSci community manager creates a new Sprint
 GitHub Project Board. Here is an example of the [2024 sprint project board](https://github.com/orgs/pyOpenSci/projects/12).
 
-The board will have several columns or statuses each or which represents the name of a sprint event (example: pyconus-2024, scipy-2024, fall-festival-2024. This board is used to:
+The board will have several columns or statuses, each of which represents the name of a sprint event (example: pyconus-2024, scipy-2024, fall-festival-2024. This board is used to:
 
 * **Track issues and pull requests opened during a sprint event**
 * **Organize and Monitor Tasks**: Keep track of the progress of tasks during the sprint, ensuring clarity on which issues are being worked on and by whom.
@@ -121,22 +123,22 @@ these items as they pop up, you are saving time spent in preparing for a sprint.
 
 pyOpenSci uses the GitHub [help-wanted project board](https://github.com/orgs/pyOpenSci/projects/3)
 to keep track of tasks that volunteers can assist with. When you see an issue
-opened or if you open an issue yourself in any of our GitHub repositories within
+opened, or if you open an issue yourself in any of our GitHub repositories within
 our [pyOpenSci GitHub organization](https://www.github.com/pyopensci), always
 consider whether the issue is something that someone else could help us with.
 
 If the issue is something that someone else in the community could do:
 
-1. **Add a `help-wanted` Label**: Any issue or pull request with the `help-wanted`
+1. **Add a `help-wanted` Label**: any issue or pull request with the `help-wanted`
    label in our organization will be automatically added to our [pyOpenSci
    help-wanted board](https://github.com/orgs/pyOpenSci/projects/3).
 
-2. **Add a `sprintable` Label (if applicable)**: If the task could be completed
+2. **Add a `sprintable` Label (if applicable)**: if the task could be completed
    during a sprint (meaning it is something that could be completed within an
    hour and up to a single day's worth of work), also add the label `sprintable`
    to the issue.
 
-3. **Update the Status on the Project Board**: Once the issue has been added to
+3. **Update the Status on the Project Board**: once the issue has been added to
    the project board (it normally takes our CI workflow 30 seconds to a minute),
    update the status of the issue on the project board based on the type of skill
    needed.
@@ -148,13 +150,13 @@ The current types of tasks in our board include:
     * Beginner friendly / non technical
     * Dev Ops / GitHub actions (Continuous Integration)
     * Python programming
-    * Website - css or ruby
+    * Website - CSS or Ruby
 
 :::{todo}
 we should add content review and sphinx as a status options for people that review our guidebook, run through tutorials etc.
 :::
 
-:::{admonition} Make sure issues contain specific detailed information before adding them to a project board
+:::{admonition} Make sure issues contain specific, detailed information before adding them to a project board
 :class: important
 
 If you are creating a new `help-wanted` issue, it's important to include as much detailed information in the issue as possible. Imagine someone else reading the issue (that is not you!). In reading the issue, does an outside contributor have:
@@ -166,7 +168,7 @@ If you are creating a new `help-wanted` issue, it's important to include as much
 When in doubt, more information is always better!
 :::
 
-Labeling issues with `help-wanted` / `sprintable` throughout the year as they are opened will save significant preparation time when a Sprint event arises. It will also make it easier for fly-by contributors to find things to help us with throughout the year.
+Labeling issues with `help-wanted` / `sprintable` throughout the year as they are opened will save significant preparation time when a sprint event arises. It will also make it easier for fly-by contributors to find things to help us with throughout the year.
 
 ## Pre-Sprint Event Tasks
 
@@ -193,7 +195,7 @@ Sprints are busy—please add as much specific information as you can to each is
 
 ### Ensure issue and pull request templates are up to date
 
-A challenge of a successful sprint is that there will be many issues and pull requests to triage after the sprint. To keep track of new issues, during an event, every pyOpenSci GitHub repository should have a sprint issue template. Adding this template only needs to be completed once. However, if there is a new pyOpenSci Github repository (this rarely happens), make sure that repo has a sprint issue template.
+One challenge of a successful sprint is that there will be many issues and pull requests to triage after the sprint. To keep track of new issues during an event, every pyOpenSci GitHub repository should have a sprint issue template. Adding this template only needs to be completed once. However, if there is a new pyOpenSci Github repository (this rarely happens), make sure that repo has a sprint issue template.
 
 The sprint template will auto-populate a `sprint-event` label on the issue or pull request when it is opened. We will then setup a GitHub action on the sprint project board for that year to auto-add any issue or pull request with the `sprint-event` label on it to the sprint project board.
 
@@ -216,7 +218,7 @@ jesse will develop this process with whatever platform we end up using...
 
 ## Tasks during a sprint
 
-Below are tasks that should occur during a spring event.
+Below are tasks that should occur during a sprint event.
 
 ### Collect participant information
 
@@ -229,7 +231,7 @@ at the event via ______ **TODO insert how we do that here** _____ following the 
 
 
 Metrics –
-Number of pr’s
+Number of PRs
 Number of issues
 Who contributed
 Where are the contributors from (country, place of work, other things??)
@@ -290,9 +292,9 @@ community, encouraging more participation and collaboration.
 ### Issue and PR triage
 The biggest effort after a sprint will be triaging & addressing issues and pull requests that have been submitted during the sprint. This could take 1-2 weeks and up to a month depending on the scope of each change submitted.
 
-If there are new issues with no associated pull request, you can
+If there are new issues with no associated pull request, you can:
 
-1. Invite the issue author to submit a pr if the change seems reasonable and they are up to the task.
+1. Invite the issue author to submit a PR if the change seems reasonable and they are up to the task.
 2. If the issue is one that we agree should be addressed, then label the issue with `help-wanted` / `sprintable`  so someone else can tackle it at our next pyOpenSci sprint.
 
 Review each pull request submitted (or invite community members to review) and determine if the pull request looks good as is or requires changes following the standard GitHub review process.
@@ -310,19 +312,19 @@ steps to take:
 2. **Provide Feedback**: Include any relevant feedback or outcomes from the sprint. This could involve sharing metrics, such as the number of issues closed, pull requests merged, or any specific contributions that stood out.
 
 3. **Invite Continued Engagement**:
-   - **Newsletter**: Encourage participants to subscribe to the pyOpenSci newsletter
+   - **Newsletter**: Encourage participants to subscribe to the [pyOpenSci newsletter](https://eepurl.com/iM7SOM)
      to stay updated on future events, news, and opportunities.
-   - **LinkedIn**: Invite them to follow pyOpenSci on LinkedIn for professional updates
+   - **LinkedIn**: Invite them to follow [pyOpenSci on LinkedIn](https://www.linkedin.com/company/pyopensci) for professional updates
      and community highlights.
    - **GitHub**: Remind them to continue following and contributing to pyOpenSci
-     repositories on GitHub.
+     [repositories on GitHub](https://github.com/pyopensci).
     - Discourse?
 
 4. **Stay Connected**:
    - **Upcoming Events**: Inform participants about upcoming sprints, webinars,
      workshops, or any other events they might be interested in.
 
-By thanking contributors you are helping to maintain the momentum generated during the sprint while also
+By thanking contributors you are helping to maintain the momentum generated during the sprint, while also
 fostering a sense of community, and encourage ongoing contributions to pyOpenSci projects.
 
 

--- a/community/events/sprints.md
+++ b/community/events/sprints.md
@@ -8,14 +8,14 @@
 
 **Before a sprint**
 
-* pyOpenSci staff go through the pyOpenSci repo issues and ensure all relevant **help-wanted** and/or **sprintable**  both have appropriated labels and have been added to the the project board in the appropriate column (beginner-friendly, python, dev-ops/ci, Python, Sphinx).
+* pyOpenSci staff go through the pyOpenSci repo issues and ensure all relevant **help-wanted** and/or **sprintable**  both have appropriated labels and have been added to the the [GitHub project](github-project) in the appropriate column (beginner-friendly, python, dev-ops/ci, Python, Sphinx).
 * pyOpenSci staff ensure all issues on the project board have enough **specific** information for a new user to follow and complete the task needed to be done. The more specific the issue is, the fewer questions a sprinter / contributor will ask during a sprint. This saves significant time and energy for both the sprint attendee and whomever is leading the sprint.
 
 **During a sprint**
 
 * Label all newly submitted issues as `sprint-event`, `sprint-name-year` (example: `sprint`, `pyconus-24`)
 * Merge small PRs that are clearly mergeable without significant review. Examples might include: typo fixes and other easy-to- review contributions.
-* For PRs, add contributors to the GitHub repository that they contributed to using the [All Contributors bot](https://allcontributors.org/) using the command: `@all-contributors add @githubusername for code, review` (if the contribution is a pull request) or  `@all-contributors add @githubusername for review` (if the contribution is an issue
+* For PRs, add contributors to the GitHub repository that they contributed to using the [All Contributors bot](https://allcontributors.org/) using the command: `@all-contributors add @githubusername for code, review` (if the contribution is a pull request) or  `@all-contributors add @githubusername for review` (if the contribution is an issue). [More on using the bot here.](all-contribs)
 * **IMPORTANT:** Merge each all-contributor-bot PR's individually and immediately after they have been opened to avoid merge conflicts
 
 **After a sprint**
@@ -88,6 +88,7 @@ significant effort during a sprint event.
 
 As such, it's important for anyone leading a sprint to come prepared! In most cases having community helpers will go along way to supporting beginner contributor success.
 
+(github-project)=
 ## Sprint infrastructure - GitHub projects
 
 To efficiently manage and track contributions during sprints, pyOpenSci utilizes
@@ -283,6 +284,7 @@ you see an issue opened that makes sense to work on remotely with a participant,
 We will need to feel some of this out at scipy.
 :::
 
+(all-contribs)=
 ### Acknowledge sprint contributors - All-Contributors Bot
 
 pyOpenSci uses the [All-Contributors bot](https://allcontributors.org/docs/en/bot/usage)

--- a/community/index.md
+++ b/community/index.md
@@ -17,3 +17,13 @@ Slack <slack>
 GitHub <github/intro>
 Our Repos <github/our-repositories>
 :::
+
+
+:::{toctree}
+:hidden:
+:caption: pyOpenSci Events
+
+Events <events/intro>
+pyOpenSci Sprints <events/sprints>
+
+:::

--- a/conf.py
+++ b/conf.py
@@ -29,7 +29,9 @@ author = "pyOpenSci"
 # Get the latest Git tag - there might be a prettier way to do this but...
 try:
     release_value = (
-        subprocess.check_output(["git", "describe", "--tags"]).decode("utf-8").strip()
+        subprocess.check_output(["git", "describe", "--tags"])
+        .decode("utf-8")
+        .strip()
     )
     release_value = release_value[:4]
 except subprocess.CalledProcessError:


### PR DESCRIPTION
I am not sure that my idea for pr templates will work. i think we will need to go the -- remote person labels things. it gets added to the board once labeled via a workflow. remote person then moves it to the right column. if we do this it could just be easier for the remote person to do all of the labeling and project board adding manually because it would be on the side of the issue or pr and not too much more work to add the project board stuff there. ... 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207456070199475