### PR TITLE
ADD: 999 to ignore-status-codes

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -52,4 +52,4 @@ jobs:
           directory: '_build/html'
           arguments: |
             --ignore-files "/.+\/_static\/.+/,/genindex.html/,/.+\/reference\/.+/"
-            --ignore-status-codes "200, 302, 404, 403, 429, 503"
+            --ignore-status-codes "200, 302, 404, 403, 429, 503, 999"

--- a/community/slack.md
+++ b/community/slack.md
@@ -14,7 +14,7 @@ Administrators in the pyOpenSci Slack space can set up [workflows](https://slack
 
 ## Setting up an automatic feed to post from GitHub into Slack:
 
-* First, grant permission to the Slack app from within GitHub (this has been completed, and can be further configured [here](https://github.com/pyOpenSci/software-submission/settings/installations). The bot was initially added via the [Slack-GitHub integration](https://slack.github.com/)). Then you can customize which Slack channels you want to use in order to track new activity on GitHub. 
+* First, grant permission to the Slack app from within GitHub (this has been completed, and can be further configured [here](https://github.com/pyOpenSci/software-submission/settings/installations). The bot was initially added via the [Slack-GitHub integration](https://slack.github.com/)). Then you can customize which Slack channels you want to use in order to track new activity on GitHub.
 * To use this integration, you can provide commands directly in the channel to connect it to a specific feed of events on GitHub. Some useful commands are:
     * **`/GitHub subscribe pyopensci/python-package-guide issues`** will allow you to subscribe to issues in the python-package-guide channel
     * **`/GitHub unsubscribe pyopensci/python-package-guide pulls`** will unsubscribe you


### PR DESCRIPTION
added 999 to ignore-status-codes to make CI happy, and stop hanging on a requirement for linkedin users to log in (per comment: https://github.com/pyOpenSci/handbook/pull/60#issuecomment-2141003542)