### PR TITLE
Add: github repo overview to the handbook

### DIFF
--- a/community/github/intro.md
+++ b/community/github/intro.md
@@ -11,3 +11,14 @@ pyOpenSci has a suite of GitHub repositories (repos) that support pyOpenSci proc
 * website content
 * tools that track contributors and keep the website up to date
 * peer review
+
+This section of the guidebook discusses our GitHub organization and processes
+for adding and managing content and infrastructure across the organization.
+
+
+:::{toctree}
+:glob:
+:maxdepth: 2
+
+*
+:::

--- a/community/github/intro.md
+++ b/community/github/intro.md
@@ -12,7 +12,7 @@ pyOpenSci has a suite of GitHub repositories (repos) that support pyOpenSci proc
 * tools that track contributors and keep the website up to date
 * peer review
 
-This section of the guidebook discusses our GitHub organization and processes
+This section of the guidebook discusses our GitHub organization, and processes
 for adding and managing content and infrastructure across the organization.
 
 

--- a/community/github/our-repositories.md
+++ b/community/github/our-repositories.md
@@ -1,13 +1,11 @@
-# Our Repositories
+# pyOpenSci GitHub Repositories
 
 :::{todo}
 Add repositories from the pyOpenSci organization.
 :::
 
-## pyOpenSci GitHub Repository Overview
-
 pyOpenSci manages multiple GitHub repositories to support various community
-activities. Below is a description of each core repository.
+activities. Below is a description of each repository.
 
 ### [Software-review Repository](https://www.pyopensci.org/software-peer-review/)
 
@@ -22,32 +20,59 @@ any changes. This template's data are processed by a Python workflow, and even
 small modifications could disrupt the language processing.
 :::
 
+## Software-peer-review Guidebook Repository
 
-### Software-peer-review Guidebook Repository
-
-This repository hosts our [software peer review guide](https://www.pyopensci.org/software-peer-review/),
-which includes instructions and guidelines for authors, editors, the editor in
-chief, and the peer review triage team. It also details our peer review policies,
+This repository hosts our [software peer review guidebook](https://www.pyopensci.org/software-peer-review/),
+which documents the processes and guidelines for authors, editors, the editor in
+chief, and the peer review triage team as they manage our open peer review process. It also details our peer review policies,
 partnerships, and the templates used in the review process.
 
-### Python-package-guide Repository
+## Python-package-guide Repository
 
 The [python-package-guide repository](https://www.pyopensci.org/python-package-guide/)
 contains our community-developed guidelines and tutorials on Python packaging.
-These resources are beginner-friendly and reflect best practices.
+These resources are beginner-friendly and reflect Python packaging best practices.
 
-### [pyosMeta Repository](https://github.com/pyOpenSci/pyosMeta)
+## [pyosMeta Repository](https://github.com/pyOpenSci/pyosMeta)
 
-The pyosMeta repo contains a Python package published on PyPI that tracks our
+The pyosMeta repository contains a Python package published on PyPI that we use to track our
 package review and contributor data. This data is used in a GitHub action to
 update our website.
 
-### [pyopensci.github.io Repository](https://github.com/pyOpenSci/pyopensci.github.io)
+:::{todo}
+Add more information about the contributor data workflow ...
+:::
 
-Our website, [pyOpenSci](https://www.pyopensci.org/), is hosted on GitHub and
-uses the Jekyll Minimal Mistakes theme. The python packages page, contributor page and peer review team page are all updated automagically using a
-GitHub action workflow that is supported by the pyosMeta Python package. The workflow runs every other week but can be triggered manually as a **workflow
+## [pyopensci.github.io Repository](https://github.com/pyOpenSci/pyopensci.github.io)
+
+This repository contains code and content that builds and publishes our pyOpenSci website. The website, [pyOpenSci](https://www.pyopensci.org/), is hosted on GitHub and
+uses the Jekyll Minimal Mistakes theme. The Python packages page, contributor page and peer review team page are all updated automagically using a
+GitHub action workflow that is supported by the pyosMeta Python package discussed above. The workflow runs every other week but can be triggered manually as a **workflow
 dispatch**.
+
+### Critical CI workflows in this repository
+
+The [contributor workflow action](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/.github/workflows/update-contribs-reviews.yml) is a custom GitHub
+action that is used to update the following website pages:
+
+* contributor page
+* package listing page
+* editorial, advisory council and executive council listing
+
+It runs as a cron job every other week but also can be run manually as a workflow
+dispatch. If you need to update our package listing or contributor list  on
+the fly, please run this action.
+
+The action will:
+
+1. parse through all of our accepted pyOpenSci packages
+2. collect package names, authors, reviewers and editors
+3. collect metadata for the packages authors reviewers and editors using the GitHub (REST) API
+4. Create 2 output YAML files discussed below.
+
+The yaml output files and then used to populate content on the website.
+
+### Metadata stored in this repository
 
 1. **Packages.yml**: Updates the [Python Packages page](https://www.pyopensci.org/python-packages.html)
    by parsing reviews from software-review repository issues.
@@ -59,7 +84,16 @@ Update the website contributors guide with general CI and specific Jekyll
 information.
 :::
 
+## [pyOpenSci Sphinx Theme](https://github.com/pyOpenSci/pyos-sphinx-theme)
+
+**Platform:** Sphinx book template that builds on top of the pydata_sphinx_theme
+
+All of our pyOpenSci sphinx books (Handbook, packaging guide, software review guide ) have been customized to match our pyOpenSci branding. This repo contains the start of a sphinx theme that will incorporate all of our branding so we do not have to manually apply the branding and update the branding individually in each repo. Rather we can update branding in the theme and it will be applied across all of our repositories that use the theme.
+
+Creating a theme was inspired by Chris Holdgraf's 2i2c Sphinx theme.
+
 ## [Handbook Repository](https://github.com/pyOpenSci/handbook)
 
-The handbook repository hosts content that helps the community navigate our
-online resources and communication channels.
+**Platform:** Sphinx book running the pydata_sphinx_theme
+
+This is where we store our organization governance, code of conduct and processes around how we operate as an organization.

--- a/community/github/our-repositories.md
+++ b/community/github/our-repositories.md
@@ -97,3 +97,10 @@ Creating a theme was inspired by Chris Holdgraf's 2i2c Sphinx theme.
 **Platform:** Sphinx book running the pydata_sphinx_theme
 
 This is where we store our organization governance, code of conduct and processes around how we operate as an organization.
+
+## [pyosPackage repository](https://github.com/pyOpenSci/pyosPackage)
+
+The pyosPackage repo contains an example pure-Python package that compliments
+our package guide & tutorials. We will build this package example out over time
+for folks that just want to see a working package without creating one
+themselves.

--- a/community/github/our-repositories.md
+++ b/community/github/our-repositories.md
@@ -23,8 +23,8 @@ small modifications could disrupt the language processing.
 ## Software-peer-review Guidebook Repository
 
 This repository hosts our [software peer review guidebook](https://www.pyopensci.org/software-peer-review/),
-which documents the processes and guidelines for authors, editors, the editor in
-chief, and the peer review triage team as they manage our open peer review process. It also details our peer review policies,
+which documents the processes and guidelines for authors, editors, the Editor in
+Chief, and the peer review triage team as they manage our open peer review process. It also details our peer review policies,
 partnerships, and the templates used in the review process.
 
 ## Python-package-guide Repository
@@ -46,7 +46,7 @@ Add more information about the contributor data workflow ...
 ## [pyopensci.github.io Repository](https://github.com/pyOpenSci/pyopensci.github.io)
 
 This repository contains code and content that builds and publishes our pyOpenSci website. The website, [pyOpenSci](https://www.pyopensci.org/), is hosted on GitHub and
-uses the Jekyll Minimal Mistakes theme. The Python packages page, contributor page and peer review team page are all updated automagically using a
+uses the [Jekyll Minimal Mistakes](https://mmistakes.github.io/minimal-mistakes/) theme. The Python packages page, contributor page and peer review team page are all updated automagically using a
 GitHub action workflow that is supported by the pyosMeta Python package discussed above. The workflow runs every other week but can be triggered manually as a **workflow
 dispatch**.
 
@@ -70,7 +70,7 @@ The action will:
 3. collect metadata for the packages authors reviewers and editors using the GitHub (REST) API
 4. Create 2 output YAML files discussed below.
 
-The yaml output files and then used to populate content on the website.
+The YAML output files and then used to populate content on the website.
 
 ### Metadata stored in this repository
 
@@ -88,9 +88,9 @@ information.
 
 **Platform:** Sphinx book template that builds on top of the pydata_sphinx_theme
 
-All of our pyOpenSci sphinx books (Handbook, packaging guide, software review guide ) have been customized to match our pyOpenSci branding. This repo contains the start of a sphinx theme that will incorporate all of our branding so we do not have to manually apply the branding and update the branding individually in each repo. Rather we can update branding in the theme and it will be applied across all of our repositories that use the theme.
+All of our pyOpenSci Sphinx books (handbook, packaging guide, software review guide ) have been customized to match our pyOpenSci branding. This repo contains the start of a Sphinx theme that will incorporate all of our branding, so we do not have to manually apply the branding and update it individually in each repo. Instead, we can update branding in the theme and it will be applied across all of our repositories that use the theme.
 
-Creating a theme was inspired by Chris Holdgraf's 2i2c Sphinx theme.
+Creating a theme was inspired by [Chris Holdgraf's](https://chrisholdgraf.com/) 2i2c Sphinx theme.
 
 ## [Handbook Repository](https://github.com/pyOpenSci/handbook)
 
@@ -100,7 +100,7 @@ This is where we store our organization governance, code of conduct and processe
 
 ## [pyosPackage repository](https://github.com/pyOpenSci/pyosPackage)
 
-The pyosPackage repo contains an example pure-Python package that compliments
+The pyosPackage repo contains an example pure-Python package that complements
 our package guide & tutorials. We will build this package example out over time
 for folks that just want to see a working package without creating one
 themselves.

--- a/community/index.md
+++ b/community/index.md
@@ -15,5 +15,4 @@ Slack <slack>
 :caption: GitHub Section
 
 GitHub <github/intro>
-Our Repos <github/our-repositories>
 :::


### PR DESCRIPTION
This pr will close in part the open draft. because it's becoming large i'm breaking it up into digestable pieces. 

This has an overview of our core github repositories. we could add examplePy in the future and pyospackage (i'll add that now actually)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207456070199491