### PR TITLE
Add: page on github issues in our organization

### DIFF
--- a/community/github/intro.md
+++ b/community/github/intro.md
@@ -1,12 +1,7 @@
 # GitHub
 
-:::{todo}
-1. for extra contributors - A pyOpenSci community member will review your post / contribution. you don't need to request a review.
-1.
-:::
-
-
-pyOpenSci has a suite of GitHub repositories (repos) that support pyOpenSci processes and content including:
+pyOpenSci has a suite of GitHub repositories (repos) that support pyOpenSci
+processes and content including:
 
 * website content
 * tools that track contributors and keep the website up to date
@@ -14,11 +9,3 @@ pyOpenSci has a suite of GitHub repositories (repos) that support pyOpenSci proc
 
 This section of the guidebook discusses our GitHub organization, and processes
 for adding and managing content and infrastructure across the organization.
-
-
-:::{toctree}
-:glob:
-:maxdepth: 2
-
-*
-:::

--- a/community/github/issues.md
+++ b/community/github/issues.md
@@ -1,82 +1,97 @@
 # pyOpenSci GitHub issue process
 
-When possible, pull requests, issue submissions and reviews should follow
-standard open source workflows. Below are guidelines for handling issues.
+When possible, GitHub pull requests, issue submissions, and reviews should follow
+standard open source workflows. Below are guidelines for handling issues in the
+pyOpenSci GitHub organization.
 
-## Guidelines for New Issues
+## Guidelines for new issues
 
-
-**Issues should be as specific as possible:** specifics within an issue help both our future selves and also outside contributors understand the goal or
-desired outcome associated with addressing the issue. This is important both internally and for issues that we tag as `help-wanted`, which we hope community members will address in pyOpenSci sprints.
+**Issues should be as specific as possible:** Specificity within an issue helps
+both our future selves and outside contributors understand the goal or desired
+outcome associated with addressing the issue. This is important both internally
+and for issues tagged as `help-wanted`, which we hope community members will
+address in pyOpenSci sprints.
 
 To ensure an issue is well-written and specific, include the following details:
 
-- **Clear Title:** A concise and descriptive title summarizing the issue or feature request helps us scan through issues and understand what each issue is about. Below are some example titles that are specific
+- **Clear title:** A concise and descriptive title summarizing the issue or
+  feature request helps us scan through issues and understand what each issue is
+  about. Below are some example titles that are specific:
 
-    * `Bug: broken link in link-to-page-here / name of page / document etc`
-    * `Fix: confusing paragraph on Python packaging with Hatch`
-    * `Add: page on using pixi for dependencies`
+  - `Bug: broken link in link-to-page-here / name of page / document etc`
+  - `Fix: confusing paragraph on Python packaging with Hatch`
+  - `Add: page on using pixi for dependencies`
 
-- **Description:** A detailed explanation of the issue or feature request, including context, background information, and the reason for the request. Explain why the issue is important and what problem it solves.
+- **Description:** A detailed explanation of the issue or feature request,
+  including context, background information, and the reason for the request.
+  Explain why the issue is important and what problem it solves.
 
-- **Screenshots/Code Samples:** Include screenshots, code snippets, links, or any other relevant files that can help others in understanding the issue better.
+- **Screenshots/code samples:** Include screenshots, code snippets, links, or
+  any other relevant files that can help others in understanding the issue
+  better.
 
-- **Possible Solutions/Recommendations:** It's helpful to provide any ideas or suggestions for how to address the issue, which can help guide contributors towards a solution.
+- **Possible solutions/recommendations:** It's helpful to provide any ideas or
+  suggestions for how to address the issue, which can help guide contributors
+  towards a solution.
 
-- **Related Issues or Pull Requests:** Add references to any related issues or pull requests, which provides additional context and understanding of the broader scope of the issue.
+- **Related issues or pull requests:** Add references to any related issues or
+  pull requests, which provides additional context and understanding of the
+  broader scope of the issue.
 
 ### If you are reporting a code bug
 
-* **Steps to Reproduce (for bugs):** A step-by-step guide (generally a list or narrative) on how to reproduce the issue, including relevant code snippets, commands, or configurations.
+- **Steps to reproduce (for bugs):** A step-by-step guide (generally a list or
+  narrative) on how to reproduce the issue, including relevant code snippets,
+  commands, or configurations.
 
-* **Expected vs. Actual Behavior (for bugs):** A description of what you expected to happen and what actually happened. This helps in understanding the discrepancy and the impact of the bug.
+- **Expected vs. actual behavior (for bugs):** A description of what you
+  expected to happen and what actually happened. This helps in understanding
+  the discrepancy and the impact of the bug.
 
-* **Environment Details (for bugs):** Details about the environment where the issue was observed, such as operating system, Python version, library versions, and any other relevant software/hardware details.
+- **Environment details (for bugs):** Details about the environment where the
+  issue was observed, such as operating system, Python version, library
+  versions, and any other relevant software/hardware details.
 
 ### If you have permissions, label the issue
 
-While outside contributors will not have permission to label issues, pyOpenSci core team members and volunteers will. Be sure to add appropriate labels to
-issues to make it easier to triage them.
+While outside contributors will not have permission to label issues, pyOpenSci
+core team members and volunteers will. Be sure to add appropriate labels to
+issues to make them easier to triage.
 
 ## Help-wanted / sprintable issues
 
-If an issue is something that anyone in the community could potentially
-address, it's ideal to label the issue with `help-wanted` and/or `sprintable`.
-A sprintable issue refers to an issue that could be completed or worked on
-during a 1-2 day sprint, thus it should be smaller and more confined in scope.
-A help-wanted issue is one that anyone is welcome to work on during whatever
-time they have available.
+If an issue is something that anyone in the community could potentially address,
+it's ideal to label the issue with `help-wanted` and/or `sprintable`. A
+sprintable issue refers to an issue that could be completed or worked on during
+a 1-2 day sprint, thus it should be smaller and more confined in scope. A
+help-wanted issue is one that anyone is welcome to work on during whatever time
+they have available.
 
 Once the `help-wanted` or `sprintable` issue label is added, the issue will be
 automatically added to our
 [pyOpenSci help-wanted board](https://github.com/orgs/pyOpenSci/projects/3).
-This automation is implemented currently for a single repository (the packaging guide), but we plan to implement it for other repositories using the add-to-project GitHub action.
-
+This automation is implemented currently for a single repository (the packaging
+guide), but we plan to implement it for other repositories using the
+add-to-project GitHub action.
 
 :::{note}
 The issue will be archived from the project board once it is closed.
 :::
 
-
-:::{todo}
-Add link to sprints page when it's online
+:::{seealso}
+[Learn more about pyOpenSci sprint events.](/community/events/sprints)
 :::
 
-If an issue is unclear, a pyOpenSci staff member or designated community
-member can ask the issue author to provide more information.
-
-
-
-
-
+If an issue is unclear, a pyOpenSci staff member or designated community member
+can ask the issue author to provide more information.
 
 :::{todo}
-Add section on labels
+Add section on labels once we have things synced up across repos.
 :::
 
-## Issue Maintenance
+## Issue maintenance
 
 Our goal at pyOpenSci is to keep our list of issues current and active.
-Quarterly issue cleanup sessions are implemented to ensure issues are
-either being actively addressed, or to assess whether older or stale issues can
+Quarterly issue cleanup sessions are implemented to ensure issues are either
+being actively addressed or to assess whether older or stale issues can
 potentially be closed.

--- a/community/github/issues.md
+++ b/community/github/issues.md
@@ -1,0 +1,82 @@
+# pyOpenSci GitHub issue process
+
+When possible, pull request and issue submissions and reviews should follow
+standard open source workflows. Below are guidelines for handling issues.
+
+## Guidelines for New Issues
+
+
+**Issues in should be as specific as possible:** specifics within an issue help both our future selves and also outside contributors understand the goal or
+desired outcome associated with addressing the issue. This is important both internally and for issues that we tag as `help-wanted`, which we hope community members will address in pyOpenSci sprints.
+
+To ensure an issue is well-written and specific, include the following details:
+
+- **Clear Title:** A concise and descriptive title summarizing the issue or feature request helps us scan through issues and understand what each issue is about. Below are some example titles that are specific
+
+    * `Bug: broken link in link-to-page-here / name of page / document etc`
+    * `Fix: confusing paragraph on Python packaging with Hatch`
+    * `Add: page on using pixi for dependencies`
+
+- **Description:** A detailed explanation of the issue or feature request, including context, background information, and the reason for the request. Explain why the issue is important and what problem it solves.
+
+- **Screenshots/Code Samples:** Screenshots, code snippets, links, or any other relevant files that can help in understanding the issue better.
+
+- **Possible Solutions/Recommendations:** Any ideas or suggestions for how to address the issue, which can help guide contributors towards a solution.
+
+- **Related Issues or Pull Requests:** References to any related issues or pull requests, providing additional context and understanding of the broader scope of the issue.
+
+### If you are reporting a code bug
+
+* **Steps to Reproduce (for bugs):** A step-by-step guide on how to reproduce the issue, including relevant code snippets, commands, or configurations.
+
+* **Expected vs. Actual Behavior (for bugs):** A description of what you expected to happen and what actually happened. This helps in understanding the discrepancy and the impact of the bug.
+
+* **Environment Details (for bugs):** Details about the environment where the issue was observed, such as operating system, Python version, library versions, and any other relevant software/hardware details.
+
+### If you have permissions, label the issue
+
+While outside contributors will not have permission to label issues, pyOpenSci core team members and volunteers will. Be sure to add appropriate labels to
+issues to make it easier to triage them.
+
+## Help-wanted / sprintable issues
+
+If an issue is something that anyone in the community could potentially
+address, it's ideal to label the issue with `help-wanted` and/or `sprintable`.
+A sprintable issue refers to an issue that could be completed or worked on
+during a 1-2 day sprint, thus it should be smaller and more confined in scope.
+A help-wanted issue is one that anyone is welcome to work on during whatever
+time they have available.
+
+Once the `help-wanted` or `sprintable` issue label is added, the issue will be
+automatically added to our
+[pyOpenSci help-wanted board](https://github.com/orgs/pyOpenSci/projects/3).
+This automation is implemented currently for a single repository (the packaging guide) but we plan to implement it for other repositories using the add-to-project GitHub action.
+
+
+:::{note}
+The issue will be archived from the project board once it is closed.
+:::
+
+
+:::{todo}
+Add link to sprints page when it's online
+:::
+
+If an issue is unclear, a pyOpenSci staff member or designated community
+member can ask the issue author to provide more information.
+
+
+
+
+
+
+:::{todo}
+Add section on labels
+:::
+
+## Issue Maintenance
+
+Our goal at pyOpenSci is to keep our list of issues current and active.
+Quarterly issue cleanup sessions should be implemented to ensure issues are
+either being actively addressed or to assess whether older or stale issues can
+be potentially closed.

--- a/community/github/issues.md
+++ b/community/github/issues.md
@@ -1,12 +1,12 @@
 # pyOpenSci GitHub issue process
 
-When possible, pull request and issue submissions and reviews should follow
+When possible, pull requests, issue submissions and reviews should follow
 standard open source workflows. Below are guidelines for handling issues.
 
 ## Guidelines for New Issues
 
 
-**Issues in should be as specific as possible:** specifics within an issue help both our future selves and also outside contributors understand the goal or
+**Issues should be as specific as possible:** specifics within an issue help both our future selves and also outside contributors understand the goal or
 desired outcome associated with addressing the issue. This is important both internally and for issues that we tag as `help-wanted`, which we hope community members will address in pyOpenSci sprints.
 
 To ensure an issue is well-written and specific, include the following details:
@@ -19,15 +19,15 @@ To ensure an issue is well-written and specific, include the following details:
 
 - **Description:** A detailed explanation of the issue or feature request, including context, background information, and the reason for the request. Explain why the issue is important and what problem it solves.
 
-- **Screenshots/Code Samples:** Screenshots, code snippets, links, or any other relevant files that can help in understanding the issue better.
+- **Screenshots/Code Samples:** Include screenshots, code snippets, links, or any other relevant files that can help others in understanding the issue better.
 
-- **Possible Solutions/Recommendations:** Any ideas or suggestions for how to address the issue, which can help guide contributors towards a solution.
+- **Possible Solutions/Recommendations:** It's helpful to provide any ideas or suggestions for how to address the issue, which can help guide contributors towards a solution.
 
-- **Related Issues or Pull Requests:** References to any related issues or pull requests, providing additional context and understanding of the broader scope of the issue.
+- **Related Issues or Pull Requests:** Add references to any related issues or pull requests, which provides additional context and understanding of the broader scope of the issue.
 
 ### If you are reporting a code bug
 
-* **Steps to Reproduce (for bugs):** A step-by-step guide on how to reproduce the issue, including relevant code snippets, commands, or configurations.
+* **Steps to Reproduce (for bugs):** A step-by-step guide (generally a list or narrative) on how to reproduce the issue, including relevant code snippets, commands, or configurations.
 
 * **Expected vs. Actual Behavior (for bugs):** A description of what you expected to happen and what actually happened. This helps in understanding the discrepancy and the impact of the bug.
 
@@ -50,7 +50,7 @@ time they have available.
 Once the `help-wanted` or `sprintable` issue label is added, the issue will be
 automatically added to our
 [pyOpenSci help-wanted board](https://github.com/orgs/pyOpenSci/projects/3).
-This automation is implemented currently for a single repository (the packaging guide) but we plan to implement it for other repositories using the add-to-project GitHub action.
+This automation is implemented currently for a single repository (the packaging guide), but we plan to implement it for other repositories using the add-to-project GitHub action.
 
 
 :::{note}
@@ -77,6 +77,6 @@ Add section on labels
 ## Issue Maintenance
 
 Our goal at pyOpenSci is to keep our list of issues current and active.
-Quarterly issue cleanup sessions should be implemented to ensure issues are
-either being actively addressed or to assess whether older or stale issues can
-be potentially closed.
+Quarterly issue cleanup sessions are implemented to ensure issues are
+either being actively addressed, or to assess whether older or stale issues can
+potentially be closed.

--- a/community/index.md
+++ b/community/index.md
@@ -1,6 +1,5 @@
 # Organization Handbook
 
-
 :::{toctree}
 :hidden:
 :caption: Social Media Section
@@ -9,14 +8,14 @@ Social Media <social>
 Slack <slack>
 :::
 
-
 :::{toctree}
 :hidden:
-:caption: GitHub Section
+:caption: GitHub Processes
 
 GitHub <github/intro>
+Our Repos <github/our-repositories>
+GitHub Issue Guidelines <github/issues>
 :::
-
 
 :::{toctree}
 :hidden:
@@ -24,5 +23,4 @@ GitHub <github/intro>
 
 Events <events/intro>
 pyOpenSci Sprints <events/sprints>
-
 :::


### PR DESCRIPTION
This pr adds a page on how we prefer to add and manage issues in our organization. 
i'm torn about whether to add information around assigning people to issues as that seems to be more sprint related (see #62 )

However now that i'm thinking about it it may not be in either page. we can open an issue once we decide where that information should live

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207635499455176