### PR TITLE
[approved] feat: add Executive Council page to handbook 

### DIFF
--- a/community/events/intro.md
+++ b/community/events/intro.md
@@ -1,3 +1,4 @@
+(pyos-events)=
 # Meetings & Events
 
 ## pyOpenSci meetings

--- a/community/index.md
+++ b/community/index.md
@@ -34,10 +34,9 @@ GitHub permissions <github/permissions>
 
 :::{toctree}
 :maxdepth: 2
+:caption: Translation & Internationalization workflows
 
-:caption: Translation workflows
-
-Events <translation>
+Translation process <translation>
 :::
 
 :::{toctree}

--- a/community/translation.md
+++ b/community/translation.md
@@ -1,3 +1,5 @@
+(translation)=
+
 # pyOpenSci GitHub processes for translation teams
 
 This document outlines the process for managing translation of pyOpenSci content in our [python-package-guide](https://github.com/pyOpenSci/python-package-guide) repository. It covers:
@@ -13,16 +15,17 @@ This document outlines the process for managing translation of pyOpenSci content
 * All questions, errors, and suggestions must be addressed before the PR is merged.
 
 These are the checks a reviewer should incorporate into their review.
+
 * Verify that the translation can be built in the PR branch without warnings
-    * Example for Spanish translation: `nox -s docs-live-lang -- es`
-    * The command can be used for any language by swapping out the language tag at the end. The current list of languages that are being actively worked on can be found in the [Packaging Guide noxfile.py](https://github.com/pyOpenSci/python-package-guide/blob/d0c05fac6c28097e60b7206e1ba5314ab869804c/noxfile.py#L45) file. A complete list of Sphinx language tags can be [found here](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language).
+  * Example for Spanish translation: `nox -s docs-live-lang -- es`
+  * The command can be used for any language by swapping out the language tag at the end. The current list of languages that are being actively worked on can be found in the [Packaging Guide noxfile.py](https://github.com/pyOpenSci/python-package-guide/blob/d0c05fac6c28097e60b7206e1ba5314ab869804c/noxfile.py#L45) file. A complete list of Sphinx language tags can be [found here](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language).
 * Go through the file and ensure that the translation makes sense, using the following checks:
-    * There are no typos
-    * Technical terms can be easily understood
-    * Sentence structure makes sense for the target language
+  * There are no typos
+  * Technical terms can be easily understood
+  * Sentence structure makes sense for the target language
 * Use suggestions for any errors that are found. This has two purposes:
-    * It makes it easier for the contributor to make changes
-    * It gives credit to the PR reviewer as a coauthor in the final commit to main
+  * It makes it easier for the contributor to make changes
+  * It gives credit to the PR reviewer as a coauthor in the final commit to main
 
 ## GitHub infrastructure for the translation teams
 
@@ -31,10 +34,12 @@ pyOpenSci will create and maintain a team for each language using CODEOWNERS fil
 The current translation teams consist of:
 
 ### Spanish
+
 * [Felipe Moreno](https://github.com/flpm)
 * [Roberto Pastor Muela](https://github.com/RobPasMue)
 
 ### Japanese
+
 * [Tetsuo Koyama](https://github.com/tkoyama010)
 * [Kozo Nishida](https://github.com/kozo2)
 
@@ -42,5 +47,5 @@ Current translation teams can expand their teams and add additional members by u
 
 ## Additional automations for consideration
 
-- Use CI to automatically tag the PR with the translation and the proper language tags.
-- Use CI to automatically keep the translation files updated once a translation has been released (work in progress [PR #397](https://github.com/pyOpenSci/python-package-guide/pull/397))
+* Use CI to automatically tag the PR with the translation and the proper language tags.
+* Use CI to automatically keep the translation files updated once a translation has been released (work in progress [PR #397](https://github.com/pyOpenSci/python-package-guide/pull/397))

--- a/community/zenodo.md
+++ b/community/zenodo.md
@@ -1,3 +1,4 @@
+(pyos-zenodo)=
 # Zenodo
 
 :::{admonition} How to cite pyOpenSci

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -36,20 +36,25 @@ Each Executive Council (EC) member dedicates no more than **four to six hours pe
   - Communicating with the Executive Director (ED) via Slack.
   - Providing timely reviews of materials and documents.
   - Connecting the Executive Director with potential funding opportunities.
-- Evaluate the performance of the Executive Director on a yearly basis.
+- Evaluate the performance of the Executive Director every year.
 - Approve expense reports.
 - Take meeting minutes and ensure they are [published in this Handbook](ec-minutes).
 
-The Executive Council is currently led by the Executive Council Chair, who approves the Executive Director’s time off requests and sick leave.
+The Executive Council is led by the Executive Council Chair, who approves the Executive Director’s time off requests and sick leave.
 
 :::{note}
-While travel is not explicitly required, members may have opportunities to attend meetings on behalf of pyOpenSci. Travel may be supported by pyOpenSci if needed.
+While travel is not explicitly required, members may have opportunities to attend meetings on behalf of pyOpenSci; pyOpenSci may support this travel as necessary.
 :::
 
 
 ## How the Executive Council makes decisions
 
-The Executive Council is required to review and approve decisions affecting the fiduciary aspects of the organization; this includes mission/vision/values, governance policies, budget, Executive Director compensation, and significant new strategic initiatives. The Executive Council also supports the Executive Director by serving as a resource for input when needed.
+:::{important}
+All decisions made by the Executive Council must align with the legal
+obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityin.org/).
+:::
+
+The Executive Council must review and approve decisions affecting the organization's fiduciary aspects. This includes the mission/vision/values, governance policies, budget, Executive Director compensation, and significant new strategic initiatives. The Executive Council also supports the Executive Director by serving as a resource for input when needed.
 
 All decisions made by the Executive Council must align with the legal
 obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityinitiatives.org/).
@@ -59,7 +64,7 @@ responsibilities.
 
 ### Decisions requiring an Executive Council vote
 
-The Executive Council (EC) defines and directs pyOpenSci’s strategy and major
+The Executive Council (EC) defines and directs pyOpenSci’s strategy and primary
 organizational direction. The EC approves significant decisions
 that strongly impact pyOpenSci’s strategy, governance, or financial well-being.
 Generally, items with legal or fiduciary implications require a formal vote,
@@ -88,23 +93,25 @@ feedback and input upon request.
 
 ### Decision-making process
 
-The topics above require a motion and a vote for approval. Motions and approval can be made in Executive Council meetings or asynchronously via email or Slack. Motions and votes will be noted in the EC meeting minutes.
+The topics above require a motion and a vote for approval. Motions and votes can be made in Executive Council meetings or via email or Slack. Motions and votes will be noted in the Executive Council meeting minutes.
 
-:::{important}
-All decisions made by the Executive Council must align with the legal
-obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityin.org/).
+:::{admonition} Executive Council Approval
+:class: important
+
+The above governance for the Executive Council was last updated, voted on, and approved on **insert-date-here**. All content below this section can be modified as needed and does not require a vote.
 :::
 
-## Collaboration between the Executive Director and the Executive Council
+## Executive Council operations
+
+### Collaboration between the Executive Director and the Executive Council
 
 The Executive Director may request feedback
-from the Executive Council on significant or public-facing decisions; these types of decisions do not require a formal vote. These discussions should
-occur in the **executive-council** Slack channel to ensure transparency and
+from the Executive Council on significant or public-facing decisions; these decisions do not require a formal vote. These discussions generally
+occur in the **executive-council** Slack channel to ensure
 collaborative input. Examples include:
 
 * Significant public-facing changes to the pyOpenSci website.
-* Decisions impacting staff or human resources (e.g., hiring or termination).
-* Operational policies for staff (unless they carry major financial implications).
+* Operational policies for staff (unless they carry significant financial implications).
 * Strategic decisions about pursuing proposals or writing grants.
 * Substantial changes to pyOpenSci programs.
 * Strategic decisions about pursuing proposals or writing grants.
@@ -113,24 +120,23 @@ collaborative input. Examples include:
 By maintaining open communication, the Executive Council and Executive Director ensure that pyOpenSci’s
 decisions align with its mission and strategic goals.
 
-### Lazy consensus for decisions that don't require a vote
+#### Lazy consensus for decisions that don't require a vote
 
 Lazy consensus is applied for decisions such as those listed above that do not require a formal vote.
 
 Lazy consensus means that decisions are approved by default unless a member of
-the Executive Council explicitly raises an objection within a predefined period.
+the Executive Council explicitly objects within a predefined period.
 This allows decisions to move forward efficiently while providing an
 opportunity for discussion.
 
 When objections are raised, further discussion occurs. This ensures decisions reflect the collective agreement of the Council
 while minimizing unnecessary delays.
 
+### How the Executive Council meets and communicates
 
-## How the Executive Council meets and communicates
+#### Monthly meetings
 
-### Monthly meetings
-
-The Executive Council holds **monthly meetings** (typically 1.5 hours) to discuss key topics, review updates, and make decisions by consensus. During these meetings, the Executive Director (ED) provides updates on the organization’s development, growth, and operations and may request feedback on specific issues. This time is also used for strategic planning and discussion
+The Executive Council holds **monthly meetings** (typically 1.5 hours) to discuss key topics, review updates, and make decisions by consensus. During these meetings, the Executive Director (ED) provides updates on the organization’s development, growth, and operations and may request feedback on specific issues. This time is also used for strategic planning and discussion.
 
 During these meetings, Council members take notes. These notes are summarized and published in the [Executive Council Minutes section of this Handbook](https://github.com/pyOpenSci/handbook/tree/main/reference/meeting-notes/executive-council).  Once the notes are merged, they are [publicly available in this Handbook](https://www.pyopensci.org/handbook/reference/meeting-notes/executive-council/intro.html).
 
@@ -140,9 +146,9 @@ During these meetings, Council members take notes. These notes are summarized an
 **Executive Director--Executive Council Chair meetings:** The Executive Director also meets regularly with the pyOpenSci Board Chair to ensure alignment on key issues and strategic direction.
 
 
-## EC communication platforms & tools
+### Communication platforms & tools
 
-### Slack: primary communication platform
+#### Slack: primary communication platform
 
 The **[Executive Council Slack channel](pyos-slack)** is the primary tool for communication between monthly meetings. All updates, discussions, and requests for input happen here; email is rarely used for EC communications.
 EC members are expected to check Slack semi-regularly to stay informed.
@@ -150,17 +156,17 @@ EC members are expected to check Slack semi-regularly to stay informed.
 - **Feedback requests:** It is understood that EC members have jobs and lives outside of their EC responsibilities. As such, when the Executive Director (ED) requests input on Slack, they will specify what feedback is needed and provide clear response timelines and areas to focus on.
 - **Transparency:** The Slack channel is also used to share updates about changes that occur outside of formal monthly meetings. Examples of such updates include new hires, event updates, and celebrating successes.
 
-### Google Drive: document sharing and collaboration
+#### Google Drive: document sharing and collaboration
 
 The pyOpenSci Executive Council uses a shared **[Google Drive](google-drive)** within the pyOpenSci Google Workspace to store and share documents. This includes meeting notes, agendas, and other important materials. Members are encouraged to access and update shared resources using the shared Drive.
 
-## Selection of Executive Council members
+### Selection of Executive Council members
 
 The Executive Council and the Executive Director are responsible for selecting and appointing new council members.
 This process ensures the Council has the skills and expertise necessary to meet
 the evolving pyOpenSci needs.
 
-### Executive Council selection process
+#### Executive Council selection process
 
 1. **Identify organization needs**:
    - The Council first evaluates its current composition to identify areas where
@@ -183,7 +189,7 @@ the evolving pyOpenSci needs.
      outlined in this document.
 
 
-### Terms and evaluation
+#### Terms and evaluation
 
 - Executive Council members are expected to serve for 2–3 years.
 - At the end of each 2-year term, members may choose to step down or renew their
@@ -192,7 +198,7 @@ the evolving pyOpenSci needs.
 As needed, the Executive Council may conduct periodic evaluations to ensure its composition continues
 to meet the organization’s needs.
 
-## Onboarding and offboarding Executive Council members
+### Onboarding and offboarding Executive Council members
 
 The onboarding and offboarding of Executive Council (EC) members ensure:
 
@@ -200,7 +206,7 @@ The onboarding and offboarding of Executive Council (EC) members ensure:
 * that new members are set up for success and
 * that departing members are appropriately transitioned out of their roles.
 
-### Onboarding a new Executive Council member
+#### Onboarding a new Executive Council member
 
 When a new member joins the Executive Council, the following steps should be
 completed to integrate them into the team:
@@ -224,9 +230,9 @@ completed to integrate them into the team:
 
 4. **Welcome and integration**:
    - Introduce the new member to the Executive Council during a meeting and to the pyOpenSci community through Slack
-     announcement. Highlight the the new member's expertise and how it complements the community and Executive Council’s needs.
+     announcement. Highlight the new member's expertise and how it complements the community and Executive Council’s needs.
 
-## Offboarding an Executive Council member
+### Offboarding an Executive Council member
 
 When a member leaves the Executive Council, the following steps should be taken
 to ensure a smooth transition:
@@ -255,7 +261,7 @@ practices.
 :::{admonition} Terms
 :class: tip
 
-* [Fiscal Sponsorship](https://en.wikipedia.org/wiki/Fiscal_sponsorship) refers to nonprofit organizations offering their legal and tax-exempt status to groups—typically projects—engaged in activities related to the sponsoring organization's mission. It involves a fee-based contractual arrangement between a project and an established non-profit.
-* [Non-Profit Organization](https://en.wikipedia.org/wiki/Nonprofit_organization): A legal entity organized and operated for a collective, public or social benefit, in contrast with an entity that operates as a business aiming to generate a profit for its owners.
+* [Fiscal Sponsorship](https://en.wikipedia.org/wiki/Fiscal_sponsorship) refers to nonprofit organizations offering their legal and tax-exempt status to groups—typically projects—engaged in activities related to the sponsoring organization's mission. It involves a fee-based contractual arrangement between a project and an established nonprofit.
+* [Nonprofit Organization](https://en.wikipedia.org/wiki/Nonprofit_organization): A legal entity organized and operated for a collective, public, or social benefit, in contrast with an entity that operates as a business aiming to generate a profit for its owners.
 * [501(c)(3) Organization](https://en.wikipedia.org/wiki/501(c)(3)_organization): a United States corporation, trust, unincorporated association, or other type of organization exempt from federal income tax under section 501(c)(3) of Title 26 of the United States Code.
 :::

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -150,8 +150,6 @@ collaborative input. Examples include:
 - Operational policies for staff (unless they carry significant financial implications).
 - Strategic decisions about pursuing proposals or writing grants.
 - Substantial changes to pyOpenSci programs.
-- Strategic decisions about pursuing proposals or writing grants.
-- Substantial changes to pyOpenSci programs.
 
 By maintaining open communication, the Executive Council and Executive Director ensure that pyOpenSci’s
 decisions align with its mission and strategic goals.

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -1,3 +1,4 @@
+(executive-council)=
 # pyOpenSci Executive Council
 
 The pyOpenSci Executive Council (EC) has four primary functions:

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -1,4 +1,5 @@
 (pyos-executive-council)=
+
 # pyOpenSci Executive Council
 
 The pyOpenSci Executive Council (EC) has four primary functions:
@@ -46,7 +47,6 @@ The Executive Council is led by the Executive Council Chair, who approves the Ex
 While travel is not explicitly required, members may have opportunities to attend meetings on behalf of pyOpenSci; pyOpenSci may support this travel as necessary.
 :::
 
-
 ## How the Executive Council makes decisions
 
 :::{important}
@@ -60,7 +60,6 @@ All decisions made by the Executive Council must align with the legal
 obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityinitiatives.org/).
 This ensures compliance with overarching governance structures and financial
 responsibilities.
-
 
 ### Decisions requiring an Executive Council vote
 
@@ -91,82 +90,13 @@ Executive Council serves as a resource for the Executive Director and may provid
 feedback and input upon request.
 :::
 
-### Decision-making process
-
-The topics above require a motion and a vote for approval. Motions and votes can be made in Executive Council meetings or via email or Slack. Motions and votes will be noted in the Executive Council meeting minutes.
-
-:::{admonition} Executive Council Approval
-:class: important
-
-The above governance for the Executive Council was last updated, voted on, and approved on **insert-date-here**. All content below this section can be modified as needed and does not require a vote.
-:::
-
-## Executive Council operations
-
-### Collaboration between the Executive Director and the Executive Council
-
-The Executive Director may request feedback
-from the Executive Council on significant or public-facing decisions; these decisions do not require a formal vote. These discussions generally
-occur in the **executive-council** Slack channel to ensure
-collaborative input. Examples include:
-
-* Significant public-facing changes to the pyOpenSci website.
-* Operational policies for staff (unless they carry significant financial implications).
-* Strategic decisions about pursuing proposals or writing grants.
-* Substantial changes to pyOpenSci programs.
-* Strategic decisions about pursuing proposals or writing grants.
-* Substantial changes to pyOpenSci programs.
-
-By maintaining open communication, the Executive Council and Executive Director ensure that pyOpenSci’s
-decisions align with its mission and strategic goals.
-
-#### Lazy consensus for decisions that don't require a vote
-
-Lazy consensus is applied for decisions such as those listed above that do not require a formal vote.
-
-Lazy consensus means that decisions are approved by default unless a member of
-the Executive Council explicitly objects within a predefined period.
-This allows decisions to move forward efficiently while providing an
-opportunity for discussion.
-
-When objections are raised, further discussion occurs. This ensures decisions reflect the collective agreement of the Council
-while minimizing unnecessary delays.
-
-### How the Executive Council meets and communicates
-
-#### Monthly meetings
-
-The Executive Council holds **monthly meetings** (typically 1.5 hours) to discuss key topics, review updates, and make decisions by consensus. During these meetings, the Executive Director (ED) provides updates on the organization’s development, growth, and operations and may request feedback on specific issues. This time is also used for strategic planning and discussion.
-
-During these meetings, Council members take notes. These notes are summarized and published in the [Executive Council Minutes section of this Handbook](https://github.com/pyOpenSci/handbook/tree/main/reference/meeting-notes/executive-council).  Once the notes are merged, they are [publicly available in this Handbook](https://www.pyopensci.org/handbook/reference/meeting-notes/executive-council/intro.html).
-
-
-**Ad hoc Executive Council meetings** are scheduled as needed to address pressing issues.
-
-**Executive Director--Executive Council Chair meetings:** The Executive Director also meets regularly with the pyOpenSci Board Chair to ensure alignment on key issues and strategic direction.
-
-
-### Communication platforms & tools
-
-#### Slack: primary communication platform
-
-The **[Executive Council Slack channel](pyos-slack)** is the primary tool for communication between monthly meetings. All updates, discussions, and requests for input happen here; email is rarely used for EC communications.
-EC members are expected to check Slack semi-regularly to stay informed.
-
-- **Feedback requests:** It is understood that EC members have jobs and lives outside of their EC responsibilities. As such, when the Executive Director (ED) requests input on Slack, they will specify what feedback is needed and provide clear response timelines and areas to focus on.
-- **Transparency:** The Slack channel is also used to share updates about changes that occur outside of formal monthly meetings. Examples of such updates include new hires, event updates, and celebrating successes.
-
-#### Google Drive: document sharing and collaboration
-
-The pyOpenSci Executive Council uses a shared **[Google Drive](google-drive)** within the pyOpenSci Google Workspace to store and share documents. This includes meeting notes, agendas, and other important materials. Members are encouraged to access and update shared resources using the shared Drive.
-
-### Selection of Executive Council members
+## How we select Executive Council members
 
 The Executive Council and the Executive Director are responsible for selecting and appointing new council members.
 This process ensures the Council has the skills and expertise necessary to meet
 the evolving pyOpenSci needs.
 
-#### Executive Council selection process
+### Executive Council selection process steps
 
 1. **Identify organization needs**:
    - The Council first evaluates its current composition to identify areas where
@@ -188,8 +118,7 @@ the evolving pyOpenSci needs.
    - Once approved, new members are onboarded following the onboarding process
      outlined in this document.
 
-
-#### Terms and evaluation
+### Terms and evaluation
 
 - Executive Council members are expected to serve for 2–3 years.
 - At the end of each 2-year term, members may choose to step down or renew their
@@ -198,13 +127,66 @@ the evolving pyOpenSci needs.
 As needed, the Executive Council may conduct periodic evaluations to ensure its composition continues
 to meet the organization’s needs.
 
+### Decision-making process
+
+The topics above require a motion and a vote for approval. Motions and votes can be made in Executive Council meetings or via email, Slack of GitHub. Motions and votes will be noted in the Executive Council meeting minutes.
+
+:::{admonition} Executive Council Approval
+:class: important
+
+The above governance for the Executive Council was last updated, voted on, and approved on **insert-date-here**. All content below this section can be modified as needed and does not require a vote.
+:::
+
+## Executive Council operations
+
+### Collaboration between the Executive Director and the Executive Council
+
+The Executive Director may request feedback
+from the Executive Council on significant or public-facing decisions; these decisions do not require a formal vote. These discussions generally
+occur in the **executive-council** Slack channel to ensure
+collaborative input. Examples include:
+
+- Significant public-facing changes to the pyOpenSci website.
+- Operational policies for staff (unless they carry significant financial implications).
+- Strategic decisions about pursuing proposals or writing grants.
+- Substantial changes to pyOpenSci programs.
+- Strategic decisions about pursuing proposals or writing grants.
+- Substantial changes to pyOpenSci programs.
+
+By maintaining open communication, the Executive Council and Executive Director ensure that pyOpenSci’s
+decisions align with its mission and strategic goals.
+
+### Lazy consensus for decisions that don't require a vote
+
+Lazy consensus is applied for decisions such as those listed above that do not require a formal vote.
+
+Lazy consensus means that decisions are approved by default unless a member of
+the Executive Council explicitly objects within a predefined period.
+This allows decisions to move forward efficiently while providing an
+opportunity for discussion.
+
+When objections are raised, further discussion occurs. This ensures decisions reflect the collective agreement of the Council
+while minimizing unnecessary delays.
+
+### How the Executive Council meets and communicates
+
+#### Monthly meetings
+
+The Executive Council holds **monthly meetings** (typically 1.5 hours) to discuss key topics, review updates, and make decisions by consensus. During these meetings, the Executive Director (ED) provides updates on the organization’s development, growth, and operations and may request feedback on specific issues. This time is also used for strategic planning and discussion.
+
+During these meetings, Council members take notes. These notes are summarized and published in the [Executive Council Minutes section of this Handbook](https://github.com/pyOpenSci/handbook/tree/main/reference/meeting-notes/executive-council).  Once the notes are merged, they are [publicly available in this Handbook](https://www.pyopensci.org/handbook/reference/meeting-notes/executive-council/intro.html).
+
+**Ad hoc Executive Council meetings** are scheduled as needed to address pressing issues.
+
+**Executive Director--Executive Council Chair meetings:** The Executive Director also meets regularly with the pyOpenSci Board Chair to ensure alignment on key issues and strategic direction.
+
 ### Onboarding and offboarding Executive Council members
 
 The onboarding and offboarding of Executive Council (EC) members ensure:
 
-* smooth transitions,
-* that new members are set up for success and
-* that departing members are appropriately transitioned out of their roles.
+- smooth transitions,
+- that new members are set up for success and
+- that departing members are appropriately transitioned out of their roles.
 
 #### Onboarding a new Executive Council member
 
@@ -232,15 +214,16 @@ completed to integrate them into the team:
    - Introduce the new member to the Executive Council during a meeting and to the pyOpenSci community through Slack
      announcement. Highlight the new member's expertise and how it complements the community and Executive Council’s needs.
 
-### Offboarding an Executive Council member
+#### Offboarding an Executive Council member
 
 When a member leaves the Executive Council, the following steps should be taken
 to ensure a smooth transition:
 
-* **Remove Access**:
-   - Remove the departing member from the pyOpenSci Executive Council shared
+- **Remove Access**:
+  - Remove the departing member from the pyOpenSci Executive Council shared
      Google Drive to ensure that sensitive information remains secure.
-   - Remove the member from the Executive Council Slack channel.
+  - Remove the member from the Executive Council Slack channel.
+
 2. **Notifications**:
    - Inform the Fiscal Sponsor (Community Initiatives) of any changes to the
      chair position or budget oversight responsibilities caused by the departure.
@@ -258,10 +241,24 @@ By following these steps, pyOpenSci ensures a seamless transition for incoming
 and outgoing members, maintaining stability and continuity in its governance
 practices.
 
+### Communication platforms & tools
+
+#### Slack: primary communication platform
+
+The **[Executive Council Slack channel](pyos-slack)** is the primary tool for communication between monthly meetings. All updates, discussions, and requests for input happen here; email is rarely used for EC communications.
+EC members are expected to check Slack semi-regularly to stay informed.
+
+- **Feedback requests:** It is understood that EC members have jobs and lives outside of their EC responsibilities. As such, when the Executive Director (ED) requests input on Slack, they will specify what feedback is needed and provide clear response timelines and areas to focus on.
+- **Transparency:** The Slack channel is also used to share updates about changes that occur outside of formal monthly meetings. Examples of such updates include new hires, event updates, and celebrating successes.
+
+#### Google Drive: document sharing and collaboration
+
+The pyOpenSci Executive Council uses a shared **[Google Drive](google-drive)** within the pyOpenSci Google Workspace to store and share documents. This includes meeting notes, agendas, and other important materials. Members are encouraged to access and update shared resources using the shared Drive.
+
 :::{admonition} Terms
 :class: tip
 
-* [Fiscal Sponsorship](https://en.wikipedia.org/wiki/Fiscal_sponsorship) refers to nonprofit organizations offering their legal and tax-exempt status to groups—typically projects—engaged in activities related to the sponsoring organization's mission. It involves a fee-based contractual arrangement between a project and an established nonprofit.
-* [Nonprofit Organization](https://en.wikipedia.org/wiki/Nonprofit_organization): A legal entity organized and operated for a collective, public, or social benefit, in contrast with an entity that operates as a business aiming to generate a profit for its owners.
-* [501(c)(3) Organization](https://en.wikipedia.org/wiki/501(c)(3)_organization): a United States corporation, trust, unincorporated association, or other type of organization exempt from federal income tax under section 501(c)(3) of Title 26 of the United States Code.
+- [Fiscal Sponsorship](https://en.wikipedia.org/wiki/Fiscal_sponsorship) refers to nonprofit organizations offering their legal and tax-exempt status to groups—typically projects—engaged in activities related to the sponsoring organization's mission. It involves a fee-based contractual arrangement between a project and an established nonprofit.
+- [Nonprofit Organization](https://en.wikipedia.org/wiki/Nonprofit_organization): A legal entity organized and operated for a collective, public, or social benefit, in contrast with an entity that operates as a business aiming to generate a profit for its owners.
+- [501(c)(3) Organization](https://en.wikipedia.org/wiki/501(c)(3)_organization): a United States corporation, trust, unincorporated association, or other type of organization exempt from federal income tax under section 501(c)(3) of Title 26 of the United States Code.
 :::

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -12,7 +12,7 @@ The pyOpenSci Executive Council (EC) has four primary functions:
 
 The Executive Director is currently a voting member of the Executive Council for items unrelated to their salary and accountability.
 
-The Executive Council holds broad expertise in building and running a scientific / data science nonprofit organization. It is complemented by the [Advisory Council](advisory-council), which offers domain-specific expertise, guidance, and input.
+The Executive Council holds broad expertise in building and running a nonprofit organization. It is complemented by the [Advisory Council](advisory-council), which offers domain-specific expertise, guidance, and input.
 
 ## How the Executive Council works
 
@@ -22,11 +22,10 @@ perspectives, the Council ensures that its guidance aligns with the organization
 [mission, vision, and values](mission-values) while meeting the needs of the
 growing pyOpenSci community.
 
-The Council employs flexible and adaptive practices, such as the **lazy consensus**
-approach, to ensure decisions are made efficiently while fostering thoughtful
+The Council employs flexible and adaptive practices to ensure decisions are made efficiently while fostering thoughtful
 dialogue and collective alignment.
 
-## Executive Council Roles & Responsibilities
+## Executive Council roles & responsibilities
 
 Each Executive Council (EC) member dedicates no more than **four to six hours per month** to pyOpenSci activities, including meeting attendance. Executive Council members are expected to fulfill the following responsibilities:
 
@@ -40,7 +39,7 @@ Each Executive Council (EC) member dedicates no more than **four to six hours pe
 - Approve expense reports.
 - Take meeting minutes and ensure they are [published in this Handbook](ec-minutes).
 
-The Executive Council is currently led by the Executive Council Chair, who approves the Executive Director’s vacation time off requests and sick leave.
+The Executive Council is currently led by the Executive Council Chair, who approves the Executive Director’s time off requests and sick leave.
 
 :::{note}
 While travel is not explicitly required, members may have opportunities to attend meetings on behalf of pyOpenSci. Travel may be supported by pyOpenSci if needed.
@@ -49,42 +48,21 @@ While travel is not explicitly required, members may have opportunities to atten
 
 ## How the Executive Council makes decisions
 
-The Executive Council supports the Executive Director by serving as a resource
-for input when needed. However, certain items require explicit Executive Council
-approval.
-
-### Decision-making process
-
-The Executive Council generally follows a **lazy consensus** approach for decision-making:
-
-:::{admonition} What is lazy consensus?
-:class: tip
-
-Lazy consensus means that decisions are approved by default unless a member of
-the Executive Council explicitly raises an objection within a predefined period.
-This allows decisions to move forward efficiently while still providing an
-opportunity for discussion. The proposal is accepted if no objections are raised
-within the specified timeframe.
-
-When objections are raised, further discussion occurs, and a formal vote is held
-if needed. This ensures decisions reflect the collective agreement of the Council
-while minimizing unnecessary delays.
-
-:::
-
+The Executive Council is required to review and approve decisions affecting the fiduciary aspects of the organization; this includes mission/vision/values, governance policies, budget, Executive Director compensation, and significant new strategic initiatives. The Executive Council also supports the Executive Director by serving as a resource for input when needed.
 
 All decisions made by the Executive Council must align with the legal
-obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityin.org/).
+obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityinitiatives.org/).
 This ensures compliance with overarching governance structures and financial
 responsibilities.
+
 
 ### Decisions requiring an Executive Council vote
 
 The Executive Council (EC) defines and directs pyOpenSci’s strategy and major
-organizational direction. It is responsible for approving significant decisions
+organizational direction. The EC approves significant decisions
 that strongly impact pyOpenSci’s strategy, governance, or financial well-being.
 Generally, items with legal or fiduciary implications require a formal vote,
-with the outcome documented in our [meeting minutes](ec-minutes).
+with the outcome documented in this handbook's Executive Council [meeting minutes](ec-minutes) section.
 
 The EC will vote on the following:
 
@@ -107,22 +85,44 @@ Executive Council serves as a resource for the Executive Director and may provid
 feedback and input upon request.
 :::
 
+### Decision-making process
+
+The topics above require a motion and a vote for approval. Motions and approval can be made in Executive Council meetings or asynchronously via email or Slack. Motions and votes will be noted in the EC meeting minutes.
+
+:::{important}
+All decisions made by the Executive Council must align with the legal
+obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityin.org/).
+:::
+
 ## Collaboration between the Executive Director and the Executive Council
 
-While not requiring a formal vote, the Executive Director may request feedback
-from the Executive Council on significant or public-facing decisions. These discussions should
+The Executive Director may request feedback
+from the Executive Council on significant or public-facing decisions; these types of decisions do not require a formal vote. These discussions should
 occur in the **executive-council** Slack channel to ensure transparency and
 collaborative input. Examples include:
 
-- Significant public-facing changes to the pyOpenSci website.
-- Decisions impacting staff or human resources (e.g., hiring or termination).
-- Operational policies for staff (unless they carry major financial implications).
-- Strategic decisions about pursuing proposals or writing grants.
-- Substantial changes to pyOpenSci programs.
+* Significant public-facing changes to the pyOpenSci website.
+* Decisions impacting staff or human resources (e.g., hiring or termination).
+* Operational policies for staff (unless they carry major financial implications).
+* Strategic decisions about pursuing proposals or writing grants.
+* Substantial changes to pyOpenSci programs.
+* Strategic decisions about pursuing proposals or writing grants.
+* Substantial changes to pyOpenSci programs.
 
-By maintaining open communication, the Executive Council and Executive Director ensure pyOpenSci’s
+By maintaining open communication, the Executive Council and Executive Director ensure that pyOpenSci’s
 decisions align with its mission and strategic goals.
 
+### Lazy consensus for decisions that don't require a vote
+
+Lazy consensus is applied for decisions such as those listed above that do not require a formal vote.
+
+Lazy consensus means that decisions are approved by default unless a member of
+the Executive Council explicitly raises an objection within a predefined period.
+This allows decisions to move forward efficiently while providing an
+opportunity for discussion.
+
+When objections are raised, further discussion occurs. This ensures decisions reflect the collective agreement of the Council
+while minimizing unnecessary delays.
 
 
 ## How the Executive Council meets and communicates
@@ -131,7 +131,7 @@ decisions align with its mission and strategic goals.
 
 The Executive Council holds **monthly meetings** (typically 1.5 hours) to discuss key topics, review updates, and make decisions by consensus. During these meetings, the Executive Director (ED) provides updates on the organization’s development, growth, and operations and may request feedback on specific issues. This time is also used for strategic planning and discussion
 
-During these meetings, Council members take notes. These notes are summarized and published in the [pyOpenSci handbook GitHub repository](https://github.com/pyOpenSci/handbook/tree/main/reference/meeting-notes/executive-council).  Once the notes are merged, they are [publicly available in this Handbook](https://www.pyopensci.org/handbook/reference/meeting-notes/executive-council/intro.html).
+During these meetings, Council members take notes. These notes are summarized and published in the [Executive Council Minutes section of this Handbook](https://github.com/pyOpenSci/handbook/tree/main/reference/meeting-notes/executive-council).  Once the notes are merged, they are [publicly available in this Handbook](https://www.pyopensci.org/handbook/reference/meeting-notes/executive-council/intro.html).
 
 
 **Ad hoc Executive Council meetings** are scheduled as needed to address pressing issues.
@@ -143,7 +143,7 @@ During these meetings, Council members take notes. These notes are summarized an
 
 ### Slack: primary communication platform
 
-The **[Executive Council Slack channel](pyos-slack)** is the primary tool for communication between monthly meetings. All updates, discussions, and requests for input happen here; email is not used for EC communications.
+The **[Executive Council Slack channel](pyos-slack)** is the primary tool for communication between monthly meetings. All updates, discussions, and requests for input happen here; email is rarely used for EC communications.
 EC members are expected to check Slack semi-regularly to stay informed.
 
 - **Feedback requests:** It is understood that EC members have jobs and lives outside of their EC responsibilities. As such, when the Executive Director (ED) requests input on Slack, they will specify what feedback is needed and provide clear response timelines and areas to focus on.
@@ -160,7 +160,6 @@ This process ensures the Council has the skills and expertise necessary to meet
 the evolving pyOpenSci needs.
 
 ### Executive Council selection process
-
 
 1. **Identify organization needs**:
    - The Council first evaluates its current composition to identify areas where
@@ -215,7 +214,7 @@ completed to integrate them into the team:
 2. **Orientation**:
    - Provide a link to this Handbook, which outlines the Council’s
      responsibilities, decision-making processes, and operational policies.
-   - Schedule an initial orientation meeting, if needed, to familiarize the new member
+   - Schedule an initial orientation meeting if needed, to familiarize the new member
      with pyOpenSci’s mission, vision, values, and ongoing initiatives.
 
 3. **Notifications**:
@@ -223,16 +222,15 @@ completed to integrate them into the team:
      that impact the chair position or budget oversight responsibilities.
 
 4. **Welcome and integration**:
-   - Introduce the new member to the Council during a meeting and through a Slack
-     announcement. Highlight their expertise and how it complements the team’s
-     needs.
+   - Introduce the new member to the Executive Council during a meeting and to the pyOpenSci community through Slack
+     announcement. Highlight the the new member's expertise and how it complements the community and Executive Council’s needs.
 
 ## Offboarding an Executive Council member
 
 When a member leaves the Executive Council, the following steps should be taken
 to ensure a smooth transition:
 
-* **Remove Access**
+* **Remove Access**:
    - Remove the departing member from the pyOpenSci Executive Council shared
      Google Drive to ensure that sensitive information remains secure.
    - Remove the member from the Executive Council Slack channel.
@@ -253,7 +251,7 @@ By following these steps, pyOpenSci ensures a seamless transition for incoming
 and outgoing members, maintaining stability and continuity in its governance
 practices.
 
-:::{admonition} Glossary
+:::{admonition} Terms
 :class: tip
 
 * [Fiscal Sponsorship](https://en.wikipedia.org/wiki/Fiscal_sponsorship) refers to nonprofit organizations offering their legal and tax-exempt status to groups—typically projects—engaged in activities related to the sponsoring organization's mission. It involves a fee-based contractual arrangement between a project and an established non-profit.

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -51,7 +51,7 @@ While travel is not explicitly required, members may have opportunities to atten
 
 :::{important}
 All decisions made by the Executive Council must align with the legal
-obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityin.org/).
+obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityinitiatives.org/).
 :::
 
 The Executive Council must review and approve decisions affecting the organization's fiduciary aspects. This includes the mission/vision/values, governance policies, budget, Executive Director compensation, and significant new strategic initiatives. The Executive Council also supports the Executive Director by serving as a resource for input when needed.

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -134,7 +134,7 @@ The topics above require a motion and a vote for approval. Motions and votes can
 :::{admonition} Executive Council Approval
 :class: important
 
-The above governance for the Executive Council was last updated, voted on, and approved on **insert-date-here**. All content below this section can be modified as needed and does not require a vote.
+The above governance for the Executive Council was last updated, voted on, and approved on **23 January 2025**. All content below this section can be modified as needed and does not require a vote.
 :::
 
 ## Executive Council operations

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -10,10 +10,21 @@ The pyOpenSci Executive Council (EC) has four primary functions:
 
 4. **Holds the [Executive Director](executive-director) accountable**: The Executive Council holds the Executive Director accountable while also providing high-level strategic and financial guidance and oversight.
 
-The Executive Director is currently a voting member of the Executive Council.
+The Executive Director is currently a voting member of the Executive Council for items unrelated to their salary and accountability.
 
 The Executive Council holds broad expertise in building and running a scientific / data science nonprofit organization. It is complemented by the [Advisory Council](advisory-council), which offers domain-specific expertise, guidance, and input.
 
+## How the Executive Council works
+
+The pyOpenSci Executive Council operates through open discussions, collaborative
+decision-making, and a commitment to transparency. By leveraging diverse
+perspectives, the Council ensures that its guidance aligns with the organization’s
+[mission, vision, and values](mission-values) while meeting the needs of the
+growing pyOpenSci community.
+
+The Council employs flexible and adaptive practices, such as the **lazy consensus**
+approach, to ensure decisions are made efficiently while fostering thoughtful
+dialogue and collective alignment.
 
 ## Executive Council Roles & Responsibilities
 
@@ -27,7 +38,7 @@ Each Executive Council (EC) member dedicates no more than **four to six hours pe
   - Connecting the Executive Director with potential funding opportunities.
 - Evaluate the performance of the Executive Director on a yearly basis.
 - Approve expense reports.
-- Take meeting minutes and ensure they are published.
+- Take meeting minutes and ensure they are [published in this Handbook](ec-minutes).
 
 The Executive Council is currently led by the Executive Council Chair, who approves the Executive Director’s vacation time off requests and sick leave.
 
@@ -35,61 +46,88 @@ The Executive Council is currently led by the Executive Council Chair, who appro
 While travel is not explicitly required, members may have opportunities to attend meetings on behalf of pyOpenSci. Travel may be supported by pyOpenSci if needed.
 :::
 
-### How the Executive Council makes decisions
 
-The Executive Council makes consensus-based decisions. All decisions must align with the legal obligations and policies of pyOpenSci’s fiscal sponsor - Community Initiatives.
+## How the Executive Council makes decisions
 
-### Items that require Executive Council approval
+The Executive Council supports the Executive Director by serving as a resource
+for input when needed. However, certain items require explicit Executive Council
+approval.
 
-In some situations, the Executive Director should consult the Executive Council to get approval before moving forward. This section describes those scenarios.
+### Decision-making process
 
-### Decisions that require an Executive Council vote
+The Executive Council generally follows a **lazy consensus** approach for decision-making:
 
-The Executive Council helps to define and direct the strategy and major direction of pyOpenSci. It must approve major decisions that strongly affect pyOpenSci’s strategy or financial well-being. In general, items with legal or fiduciary implications require a vote and the public documentation of the vote's outcome via our [meeting minutes](ec-minutes).
+:::{admonition} What is lazy consensus?
+:class: tip
 
-The EC will always vote on the following:
+Lazy consensus means that decisions are approved by default unless a member of
+the Executive Council explicitly raises an objection within a predefined period.
+This allows decisions to move forward efficiently while still providing an
+opportunity for discussion. The proposal is accepted if no objections are raised
+within the specified timeframe.
 
-* Annual Budget
-* Anything related to pyOpenSci's Mission, vision, values
-* Changes in governance and policy (example COC)
-    * Changes to the Code of Conduct.
-* Significant deviations from the approved yearly budget
-* Decisions that have significant implications for pyOpenSci’s financial health.
-* Major changes in strategic direction and roadmaps for organization development.
+When objections are raised, further discussion occurs, and a formal vote is held
+if needed. This ensures decisions reflect the collective agreement of the Council
+while minimizing unnecessary delays.
 
-The EC, independent of the Executive Director, also determines the Executive Director's salary.
-
-The Executive Director is given authority to make all other decisions; the Executive Council, however, is a resource for the Executive Director  when they want feedback and input on decisions.
-
-
-### The Executive Council may also be asked to provide input on
-
-These decisions are significant or public-facing and would benefit from the input of the Executive Council; they do not require a vote to move forward. The Executive Council should be notified using the **executive-council** slack channel.
-
-Here are some items that you may be asked for feedback on.
-
-* Significant public-facing changes to the pyOpenSci website.
-* Significant changes that impact staff or Human Resources (hiring, firing ,etc) decisions.
-* Operational policy for pyOpenSci staff (unless they have major financial implications).
-* Decisions about pursuing proposals and writing grants.
-* Decisions about significant changes to pyOpenSci programs
+:::
 
 
+All decisions made by the Executive Council must align with the legal
+obligations and policies of pyOpenSci’s fiscal sponsor—[Community Initiatives](https://communityin.org/).
+This ensures compliance with overarching governance structures and financial
+responsibilities.
 
-## The Executive Council's Role
+### Decisions requiring an Executive Council vote
 
-The Executive Council is available as a resource for the Executive Director when it is helpful. However, there are also items that require Executive Council approval.
+The Executive Council (EC) defines and directs pyOpenSci’s strategy and major
+organizational direction. It is responsible for approving significant decisions
+that strongly impact pyOpenSci’s strategy, governance, or financial well-being.
+Generally, items with legal or fiduciary implications require a formal vote,
+with the outcome documented in our [meeting minutes](ec-minutes).
+
+The EC will vote on the following:
+
+- **Annual budget**: Approval of the organization's yearly budget.
+- **Mission, vision, and values**: Decisions related to pyOpenSci’s core principles.
+- **Governance and policy changes**: Approval of changes to governance structures,
+  including updates to the Code of Conduct.
+- **Significant budget deviations**: Decisions involving major deviations from the
+  approved annual budget.
+- **Financial health implications**: Any decision with substantial implications for
+  pyOpenSci’s financial stability.
+- **Strategic direction**: Approval of major changes to organizational strategy and
+  development roadmaps.
+- **Executive director’s salary**: The EC independently determines the salary of the
+  Executive Director.
+
+:::note
+The Executive Director is authorized to make all other decisions. However, the
+Executive Council serves as a resource for the Executive Director and may provide
+feedback and input upon request.
+:::
+
+## Collaboration between the Executive Director and the Executive Council
+
+While not requiring a formal vote, the Executive Director may request feedback
+from the Executive Council on significant or public-facing decisions. These discussions should
+occur in the **executive-council** Slack channel to ensure transparency and
+collaborative input. Examples include:
+
+- Significant public-facing changes to the pyOpenSci website.
+- Decisions impacting staff or human resources (e.g., hiring or termination).
+- Operational policies for staff (unless they carry major financial implications).
+- Strategic decisions about pursuing proposals or writing grants.
+- Substantial changes to pyOpenSci programs.
+
+By maintaining open communication, the Executive Council and Executive Director ensure pyOpenSci’s
+decisions align with its mission and strategic goals.
 
 
-## How the Executive Council works
 
-The pyOpenSci Executive Council operates through open discussions, collaborative decision-making, and a "lazy consensus" principle where decisions move forward unless concerns are explicitly raised. This flexible and adaptive approach ensures that the Executive Council can respond to the needs of the growing pyOpenSci community of practice. We focus on fostering thoughtful dialogue and leveraging diverse perspectives to guide the organization’s [mission, vision, and values](mission-values).
+## How the Executive Council meets and communicates
 
-The Executive Council values transparency and clarity, ensuring all members are informed and aligned as we shape the future of pyOpenSci together.
-
-### How we meet and communicate
-
-#### Monthly meetings
+### Monthly meetings
 
 The Executive Council holds **monthly meetings** (typically 1.5 hours) to discuss key topics, review updates, and make decisions by consensus. During these meetings, the Executive Director (ED) provides updates on the organization’s development, growth, and operations and may request feedback on specific issues. This time is also used for strategic planning and discussion
 
@@ -115,42 +153,110 @@ EC members are expected to check Slack semi-regularly to stay informed.
 
 The pyOpenSci Executive Council uses a shared **[Google Drive](google-drive)** within the pyOpenSci Google Workspace to store and share documents. This includes meeting notes, agendas, and other important materials. Members are encouraged to access and update shared resources using the shared Drive.
 
-### MOVE Guiding principle: lazy consensus
+## Selection of Executive Council members
 
-The EC operates using a "lazy consensus" principle, where decisions move forward unless concerns are explicitly raised. This approach ensures efficient decision-making while allowing members to provide feedback when necessary.
+The Executive Council and the Executive Director are responsible for selecting and appointing new council members.
+This process ensures the Council has the skills and expertise necessary to meet
+the evolving pyOpenSci needs.
 
-:::{todo}
-Find a good link to explain the concept of lazy consensus.
-:::
-
-
+### Executive Council selection process
 
 
+1. **Identify organization needs**:
+   - The Council first evaluates its current composition to identify areas where
+     additional expertise, perspectives, or skills could be useful to support the
+     organization’s mission and strategy.
 
-## Onboarding a new Executive Council member
+2. **Identify Candidates**:
+   - Potential candidates are identified based on their experience, expertise,
+     and alignment with pyOpenSci’s mission, vision, and values. This may include
+     leaders in the open science community, individuals with financial or
+     governance expertise, or others with relevant nonprofit governance skills.
 
-* Add to pyOpenSci Executive Council shared drive
-* Add to pyOpenSci Executive Council Slack channel
-* Notify our Fiscal Sponsors of a change in chair or budget oversight role
-* Provide links to relevant documentation in the Handbook (other places?)
+3. **Review and nominate the new member**:
+   - Candidates are discussed and nominated by current Council members during a
+     meeting or through the Executive Council Slack channel. After nomination, the Executive Director
+     will contact the candidate to see if they are interested/available.
 
+5. **Onboard the new candidate**:
+   - Once approved, new members are onboarded following the onboarding process
+     outlined in this document.
+
+
+### Terms and evaluation
+
+- Executive Council members are expected to serve for 2–3 years.
+- At the end of each 2-year term, members may choose to step down or renew their
+  commitment based on mutual agreement with the Council.
+
+As needed, the Executive Council may conduct periodic evaluations to ensure its composition continues
+to meet the organization’s needs.
+
+## Onboarding and offboarding Executive Council members
+
+The onboarding and offboarding of Executive Council (EC) members ensure:
+
+* smooth transitions,
+* that new members are set up for success and
+* that departing members are appropriately transitioned out of their roles.
+
+### Onboarding a new Executive Council member
+
+When a new member joins the Executive Council, the following steps should be
+completed to integrate them into the team:
+
+1. **Access to tools and resources**:
+   - Add the new member to the pyOpenSci Executive Council shared [Google Drive](google-drive).
+     This drive is where we share meeting notes,
+     agendas, budgets and other resources.
+   - Add the new member to the Executive Council Slack channel, the primary
+     communication platform for the Council.
+
+2. **Orientation**:
+   - Provide a link to this Handbook, which outlines the Council’s
+     responsibilities, decision-making processes, and operational policies.
+   - Schedule an initial orientation meeting, if needed, to familiarize the new member
+     with pyOpenSci’s mission, vision, values, and ongoing initiatives.
+
+3. **Notifications**:
+   - Notify the pyOpenSci's Fiscal Sponsor (Community Initiatives) of any changes in roles
+     that impact the chair position or budget oversight responsibilities.
+
+4. **Welcome and integration**:
+   - Introduce the new member to the Council during a meeting and through a Slack
+     announcement. Highlight their expertise and how it complements the team’s
+     needs.
 
 ## Offboarding an Executive Council member
 
-* Remove from pyOpenSci executive council shared drive
-* Remove from pyOpenSci Executive Council Slack channel
-* Notify CI if there is a change to the chair and budget role
+When a member leaves the Executive Council, the following steps should be taken
+to ensure a smooth transition:
 
+* **Remove Access**
+   - Remove the departing member from the pyOpenSci Executive Council shared
+     Google Drive to ensure that sensitive information remains secure.
+   - Remove the member from the Executive Council Slack channel.
+2. **Notifications**:
+   - Inform the Fiscal Sponsor (Community Initiatives) of any changes to the
+     chair position or budget oversight responsibilities caused by the departure.
 
-## Selection of Executive Council members
+3. **Knowledge transfer**:
+   - If the departing member held specific responsibilities or roles (e.g.,
+     chair, budget oversight), ensure that these responsibilities are transitioned
+     to another member of the Council.
+4. **Acknowledgment and thanks**:
+   - Publicly thank the departing member for their contributions to pyOpenSci,
+     either during a meeting or through a Slack message. Celebrate their impact
+     on the organization and its mission.
 
-* New members will be selected and appointed by the existing Executive Council
-* We will select new members by assessing the governance needs of the organization and identifying a person with that experience/expertise to join the EC.
-*
+By following these steps, pyOpenSci ensures a seamless transition for incoming
+and outgoing members, maintaining stability and continuity in its governance
+practices.
 
-
-## Glossary
+:::{admonition} Glossary
+:class: tip
 
 * [Fiscal Sponsorship](https://en.wikipedia.org/wiki/Fiscal_sponsorship) refers to nonprofit organizations offering their legal and tax-exempt status to groups—typically projects—engaged in activities related to the sponsoring organization's mission. It involves a fee-based contractual arrangement between a project and an established non-profit.
 * [Non-Profit Organization](https://en.wikipedia.org/wiki/Nonprofit_organization): A legal entity organized and operated for a collective, public or social benefit, in contrast with an entity that operates as a business aiming to generate a profit for its owners.
 * [501(c)(3) Organization](https://en.wikipedia.org/wiki/501(c)(3)_organization): a United States corporation, trust, unincorporated association, or other type of organization exempt from federal income tax under section 501(c)(3) of Title 26 of the United States Code.
+:::

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -1,0 +1,156 @@
+# pyOpenSci Executive Council
+
+The pyOpenSci Executive Council (EC) has four primary functions:
+
+1. **Guides the Organization**: The Executive Council defines and directs pyOpenSci’s high-level [mission, vision, and values](mission-values) and sets its strategic direction.
+
+2. **Advocates for pyOpenSci**: The Executive Council serves as an advocate and ambassador for the organization, leveraging members’ networks to enhance its reputation and support fundraising efforts.
+
+3. **Provides Strategic Insight**: The Executive Council offers perspective and guidance on major strategic decisions to ensure the organization’s long-term success.
+
+4. **Holds the [Executive Director](executive-director) accountable**: The Executive Council holds the Executive Director accountable while also providing high-level strategic and financial guidance and oversight.
+
+The Executive Director is currently a voting member of the Executive Council.
+
+The Executive Council holds broad expertise in building and running a scientific / data science nonprofit organization. It is complemented by the [Advisory Council](advisory-council), which offers domain-specific expertise, guidance, and input.
+
+
+## Executive Council Roles & Responsibilities
+
+Each Executive Council (EC) member dedicates no more than **four to six hours per month** to pyOpenSci activities, including meeting attendance. Executive Council members are expected to fulfill the following responsibilities:
+
+- Attend at least 80% of monthly Executive Council meetings.
+- Participate in asynchronous commitments, which include:
+  - Suggesting agenda items for meetings.
+  - Communicating with the Executive Director (ED) via Slack.
+  - Providing timely reviews of materials and documents.
+  - Connecting the Executive Director with potential funding opportunities.
+- Evaluate the performance of the Executive Director on a yearly basis.
+- Approve expense reports.
+- Take meeting minutes and ensure they are published.
+
+The Executive Council is currently led by the Executive Council Chair, who approves the Executive Director’s vacation time off requests and sick leave.
+
+:::{note}
+While travel is not explicitly required, members may have opportunities to attend meetings on behalf of pyOpenSci. Travel may be supported by pyOpenSci if needed.
+:::
+
+### How the Executive Council makes decisions
+
+The Executive Council makes consensus-based decisions. All decisions must align with the legal obligations and policies of pyOpenSci’s fiscal sponsor - Community Initiatives.
+
+### Items that require Executive Council approval
+
+In some situations, the Executive Director should consult the Executive Council to get approval before moving forward. This section describes those scenarios.
+
+### Decisions that require an Executive Council vote
+
+The Executive Council helps to define and direct the strategy and major direction of pyOpenSci. It must approve major decisions that strongly affect pyOpenSci’s strategy or financial well-being. In general, items with legal or fiduciary implications require a vote and the public documentation of the vote's outcome via our [meeting minutes](ec-minutes).
+
+The EC will always vote on the following:
+
+* Annual Budget
+* Anything related to pyOpenSci's Mission, vision, values
+* Changes in governance and policy (example COC)
+    * Changes to the Code of Conduct.
+* Significant deviations from the approved yearly budget
+* Decisions that have significant implications for pyOpenSci’s financial health.
+* Major changes in strategic direction and roadmaps for organization development.
+
+The EC, independent of the Executive Director, also determines the Executive Director's salary.
+
+The Executive Director is given authority to make all other decisions; the Executive Council, however, is a resource for the Executive Director  when they want feedback and input on decisions.
+
+
+### The Executive Council may also be asked to provide input on
+
+These decisions are significant or public-facing and would benefit from the input of the Executive Council; they do not require a vote to move forward. The Executive Council should be notified using the **executive-council** slack channel.
+
+Here are some items that you may be asked for feedback on.
+
+* Significant public-facing changes to the pyOpenSci website.
+* Significant changes that impact staff or Human Resources (hiring, firing ,etc) decisions.
+* Operational policy for pyOpenSci staff (unless they have major financial implications).
+* Decisions about pursuing proposals and writing grants.
+* Decisions about significant changes to pyOpenSci programs
+
+
+
+## The Executive Council's Role
+
+The Executive Council is available as a resource for the Executive Director when it is helpful. However, there are also items that require Executive Council approval.
+
+
+## How the Executive Council works
+
+The pyOpenSci Executive Council operates through open discussions, collaborative decision-making, and a "lazy consensus" principle where decisions move forward unless concerns are explicitly raised. This flexible and adaptive approach ensures that the Executive Council can respond to the needs of the growing pyOpenSci community of practice. We focus on fostering thoughtful dialogue and leveraging diverse perspectives to guide the organization’s [mission, vision, and values](mission-values).
+
+The Executive Council values transparency and clarity, ensuring all members are informed and aligned as we shape the future of pyOpenSci together.
+
+### How we meet and communicate
+
+#### Monthly meetings
+
+The Executive Council holds **monthly meetings** (typically 1.5 hours) to discuss key topics, review updates, and make decisions by consensus. During these meetings, the Executive Director (ED) provides updates on the organization’s development, growth, and operations and may request feedback on specific issues. This time is also used for strategic planning and discussion
+
+During these meetings, Council members take notes. These notes are summarized and published in the [pyOpenSci handbook GitHub repository](https://github.com/pyOpenSci/handbook/tree/main/reference/meeting-notes/executive-council).  Once the notes are merged, they are [publicly available in this Handbook](https://www.pyopensci.org/handbook/reference/meeting-notes/executive-council/intro.html).
+
+
+**Ad hoc Executive Council meetings** are scheduled as needed to address pressing issues.
+
+**Executive Director--Executive Council Chair meetings:** The Executive Director also meets regularly with the pyOpenSci Board Chair to ensure alignment on key issues and strategic direction.
+
+
+## EC communication platforms & tools
+
+### Slack: primary communication platform
+
+The **[Executive Council Slack channel](pyos-slack)** is the primary tool for communication between monthly meetings. All updates, discussions, and requests for input happen here; email is not used for EC communications.
+EC members are expected to check Slack semi-regularly to stay informed.
+
+- **Feedback requests:** It is understood that EC members have jobs and lives outside of their EC responsibilities. As such, when the Executive Director (ED) requests input on Slack, they will specify what feedback is needed and provide clear response timelines and areas to focus on.
+- **Transparency:** The Slack channel is also used to share updates about changes that occur outside of formal monthly meetings. Examples of such updates include new hires, event updates, and celebrating successes.
+
+### Google Drive: document sharing and collaboration
+
+The pyOpenSci Executive Council uses a shared **[Google Drive](google-drive)** within the pyOpenSci Google Workspace to store and share documents. This includes meeting notes, agendas, and other important materials. Members are encouraged to access and update shared resources using the shared Drive.
+
+### MOVE Guiding principle: lazy consensus
+
+The EC operates using a "lazy consensus" principle, where decisions move forward unless concerns are explicitly raised. This approach ensures efficient decision-making while allowing members to provide feedback when necessary.
+
+:::{todo}
+Find a good link to explain the concept of lazy consensus.
+:::
+
+
+
+
+
+## Onboarding a new Executive Council member
+
+* Add to pyOpenSci Executive Council shared drive
+* Add to pyOpenSci Executive Council Slack channel
+* Notify our Fiscal Sponsors of a change in chair or budget oversight role
+* Provide links to relevant documentation in the Handbook (other places?)
+
+
+## Offboarding an Executive Council member
+
+* Remove from pyOpenSci executive council shared drive
+* Remove from pyOpenSci Executive Council Slack channel
+* Notify CI if there is a change to the chair and budget role
+
+
+## Selection of Executive Council members
+
+* New members will be selected and appointed by the existing Executive Council
+* We will select new members by assessing the governance needs of the organization and identifying a person with that experience/expertise to join the EC.
+*
+
+
+## Glossary
+
+* [Fiscal Sponsorship](https://en.wikipedia.org/wiki/Fiscal_sponsorship) refers to nonprofit organizations offering their legal and tax-exempt status to groups—typically projects—engaged in activities related to the sponsoring organization's mission. It involves a fee-based contractual arrangement between a project and an established non-profit.
+* [Non-Profit Organization](https://en.wikipedia.org/wiki/Nonprofit_organization): A legal entity organized and operated for a collective, public or social benefit, in contrast with an entity that operates as a business aiming to generate a profit for its owners.
+* [501(c)(3) Organization](https://en.wikipedia.org/wiki/501(c)(3)_organization): a United States corporation, trust, unincorporated association, or other type of organization exempt from federal income tax under section 501(c)(3) of Title 26 of the United States Code.

--- a/governance/executive-council.md
+++ b/governance/executive-council.md
@@ -1,4 +1,4 @@
-(executive-council)=
+(pyos-executive-council)=
 # pyOpenSci Executive Council
 
 The pyOpenSci Executive Council (EC) has four primary functions:

--- a/governance/index.md
+++ b/governance/index.md
@@ -19,6 +19,7 @@ pyOpenSci supports open science through
 Home <self>
 mission-values
 structure
+Executive Council <executive-council>
 Code of Conduct <../CODE_OF_CONDUCT.md>
 ```
 

--- a/governance/mission-values.md
+++ b/governance/mission-values.md
@@ -1,4 +1,4 @@
-# Mission and values
+# Mission, Vision and Values
 
 The mission of pyOpenSci is to support diverse community around the free, open
 python tools that drive open, reproducible scientific workflows.

--- a/governance/mission-values.md
+++ b/governance/mission-values.md
@@ -1,3 +1,4 @@
+(mission-vision)=
 # Mission, Vision and Values
 
 The mission of pyOpenSci is to support diverse community around the free, open

--- a/governance/structure.md
+++ b/governance/structure.md
@@ -1,4 +1,5 @@
 (pyos-structure)=
+
 # Organization Structure and Leadership
 
 This page describes the organizational structure of pyOpenSci as they
@@ -18,6 +19,7 @@ The Executive Director (discussed below) is a voting member of the executive cou
 [Click here to view current executive council members](https://www.pyopensci.org/our-community/#executive-council--leadership)
 
 (advisory-council)=
+
 ### pyOpenSci advisory council
 
 [Click here to view current advisory council members.](https://www.pyopensci.org/our-community/#pyopensci-advisory-council)
@@ -39,6 +41,7 @@ on the high-level goals of pyOpenSci programs.
 ## Staff roles within the organization
 
 (executive-director)=
+
 ### Executive Director
 
 The Executive Director creates and oversees the execution of the mission and
@@ -60,6 +63,7 @@ will take on other responsibilities including:
 - Serving as the defacto Software Peer Review Lead (below) until that position is funded.
 
 :::{todo}
+
 ### Community Manager
 
 The Community Manager is a future position to be created within the pyOpenSci
@@ -77,7 +81,6 @@ The Community Manager is a paid position in the pyOpenSci organization.
 ## Open peer review program: Program-level leadership structure
 
 Several roles and groups drive the peer review process:
-
 
 ### Software review lead
 
@@ -121,7 +124,7 @@ The review process is supported by volunteer reviewers.
 ## Fiscal sponsorship
 
 pyOpenSci is a fiscally sponsored project of [Community
-Initiatives](https://www.communityin.org).
+Initiatives](https://communityinitiatives.org).
 
 pyOpenSci does not have its own standalone non-profit status. Instead,
 it inherits this status by being a fiscally sponsored project. This

--- a/governance/structure.md
+++ b/governance/structure.md
@@ -1,3 +1,4 @@
+(pyos-structure)=
 # Organization Structure and Leadership
 
 This page describes the organizational structure of pyOpenSci as they

--- a/governance/structure.md
+++ b/governance/structure.md
@@ -4,13 +4,13 @@ This page describes the organizational structure of pyOpenSci as they
 related to governance and operations.
 
 There are two levels of leadership described below.
-The first is organizational level. The second is program level.
+The first is the organizational level. The second is program level.
 
 ## Governing Committees
 
 ### Executive Council
 
-The Executive Council defines and steers the high-level
+The [Executive Council](executive-council) defines and steers the high-level
 mission, vision and values of pyOpenSci. It also sets the strategic direction and vision for the organization.
 The Executive Director (discussed below) is a voting member of the executive council.
 
@@ -21,9 +21,9 @@ The Executive Director (discussed below) is a voting member of the executive cou
 
 [Click here to view current advisory council members.](https://www.pyopensci.org/our-community/#pyopensci-advisory-council)
 
-The advisory council is comprised of leaders in the Python scientific
+The Advisory Council is comprised of leaders in the Python scientific
 open source ecosystem. This council advises the executive director
-in both organization level and day to day decision making around
+in both organization level and day-to-day decision-making around
 
 - Python packaging guidelines
 - Peer review processes and guidelines
@@ -32,8 +32,8 @@ in both organization level and day to day decision making around
 
 Most of the communication supporting advisory council activities
 happens in the pyOpenSci slack. The executive director will also
-organize several executive council meetings a year that will focus
-on high level goals of pyOpenSci programs.
+organize monthly [Executive Council](executive-council) meetings that  focus
+on the high-level goals of pyOpenSci programs.
 
 ## Staff roles within the organization
 
@@ -44,40 +44,39 @@ The Executive Director creates and oversees the execution of the mission and
 strategy of pyOpenSci supported by the Advisory Committee. The Executive Director
 also:
 
-- is the the primary interface to the organization's fiscal sponsor;
-- coordinates day to day activities
-- develops programs that drive the organizations mission
+- is the primary interface to the organization's fiscal sponsor;
+- coordinates day-to-day activities
+- develops programs that drive the organization's mission
 - oversees staff and volunteers
-- makes tie-breaking decisions if they are at an impasse in decision-making.
+- makes tie-breaking decisions if they are at an impasse.
 
-The Executive Director reports to the Advisory Committee.
+The Executive Director reports to the Executive Council.
 
-In the early stages of the organization's development the Executive Director
+In the early stages of the organization's development, the Executive Director
 will take on other responsibilities including:
 
-- Managing the community in Slack and twitter
+- Managing the community in Slack and on social media
 - Serving as the defacto Software Peer Review Lead (below) until that position is funded.
 
-### Community manager
+:::{todo}
+### Community Manager
 
 The Community Manager is a future position to be created within the pyOpenSci
 organization. This position will:
 
 - Oversee social media communications
 - Create strategic communication plans
-- Write and oversee writing of blogs
+- Write and oversee blog writing
 - Manage website content
-- Support communications within our online communication platforms (e.g. Slack, discourse, etc)
+- Support communications within our online communication platforms (e.g. Slack, Discourse, Discord etc.)
 
 The Community Manager is a paid position in the pyOpenSci organization.
+:::
 
-## Open Peer Review Program: Program level leadership structure
+## Open peer review program: Program-level leadership structure
 
-The peer review process is driven by several roles and groups:
+Several roles and groups drive the peer review process:
 
-% <TODO: right now the leadership of peer review is kind of clear in my head
-% but not clear in the documentation for peer review. Fix this. Add a
-% Peer review structure document or section somewhere... >
 
 ### Software review lead
 

--- a/governance/structure.md
+++ b/governance/structure.md
@@ -11,7 +11,7 @@ The first is the organizational level. The second is program level.
 
 ### Executive Council
 
-The [Executive Council](executive-council) defines and steers the high-level
+The [Executive Council](pyos-executive-council) defines and steers the high-level
 mission, vision and values of pyOpenSci. It also sets the strategic direction and vision for the organization.
 The Executive Director (discussed below) is a voting member of the executive council.
 
@@ -33,7 +33,7 @@ in both organization level and day-to-day decision-making around
 
 Most of the communication supporting advisory council activities
 happens in the pyOpenSci slack. The executive director will also
-organize monthly [Executive Council](executive-council) meetings that  focus
+organize monthly [Executive Council](pyos-executive-council) meetings that  focus
 on the high-level goals of pyOpenSci programs.
 
 ## Staff roles within the organization

--- a/governance/structure.md
+++ b/governance/structure.md
@@ -1,4 +1,4 @@
-# Structure and leadership
+# Organization Structure and Leadership
 
 This page describes the organizational structure of pyOpenSci as they
 related to governance and operations.
@@ -16,6 +16,7 @@ The Executive Director (discussed below) is a voting member of the executive cou
 
 [Click here to view current executive council members](https://www.pyopensci.org/our-community/#executive-council--leadership)
 
+(advisory-council)=
 ### pyOpenSci advisory council
 
 [Click here to view current advisory council members.](https://www.pyopensci.org/our-community/#pyopensci-advisory-council)
@@ -36,6 +37,7 @@ on high level goals of pyOpenSci programs.
 
 ## Staff roles within the organization
 
+(executive-director)=
 ### Executive Director
 
 The Executive Director creates and oversees the execution of the mission and

--- a/index.md
+++ b/index.md
@@ -6,17 +6,31 @@ that support pyOpenSci operations.
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/pyopensci/governance?color=purple&display_name=tag&style=plastic)](https://github.com/pyOpenSci/handbook/releases) [![DOI](https://zenodo.org/badge/161679308.svg)](https://zenodo.org/badge/latestdoi/161679308) [![All Contributors](https://img.shields.io/badge/all_contributors-3-blue.svg?style=flat-square)](https://github.com/pyOpenSci/handbook?tab=readme-ov-file#contributors-)
 
 
-:::::{grid} 1 1 3 3
+:::::{grid} 1 1 2 2
 :class-container: text-center
 :gutter: 3
 
 ::::{grid-item}
 :::{card} ✿ Governance, Structure and Values ✿
 :class-card: left-aligned
-:link: organization/index
-:link-type: doc
 
-Learn more about the governance structure of pyOpenSci.
+Learn more about pyOpenSci's:
+
+* [Mission, vision, and values](mission-vision)
+* [Organization and structure](pyos-structure)
+* [Executive council & leadership structure](executive-council)
+:::
+::::
+
+::::{grid-item}
+:::{card} <i class="fa-solid fa-screwdriver-wrench"></i> Our Organization <i class="fa-solid fa-screwdriver-wrench"></i>
+:link: organization/index
+
+Learn about [how we work](how-we-work) at pyOpenSci.
+
+* How we [engage with the community](external-comms).
+* [Our brand](pyos-brand)
+* Our [social platforms and channels](social-platforms).
 :::
 ::::
 
@@ -26,42 +40,23 @@ Learn more about the governance structure of pyOpenSci.
 :link: community/index
 :link-type: doc
 
-Learn more about the vibrant pyOpenSci open science & open source community of practice.
+Learn more about the vibrant pyOpenSci community of practice.
+
+* [How we use GitHub](github-intro)
+* [About our events](pyos-events)
+* Community platforms that we use which include [Slack](pyos-slack) and [Zenodo](pyos-zenodo).
+
 :::
 ::::
 
 ::::{grid-item}
-:::{card} <i class="fa-solid fa-screwdriver-wrench"></i> Our Organization <i class="fa-solid fa-screwdriver-wrench"></i>
-:link: organization/index
-:link-type: doc
-:class-card: left-aligned
+:::{card} ✿ Code of Conduct & Contributing ✿
 
-<i class="fa-solid fa-triangle-exclamation"></i> **This section is under heavy development!**
-
-Learn about how we work, the platforms we use, and how we engage with the community.
+* Our [code of conduct](CODE_OF_CONDUCT) applies to all members of the pyOpenSci community. And to those participating in pyOpenSci-supported events.
+* Our [Contributing guide](CONTRIBUTING) will help you get oriented to contributing to pyOpenSci.
 :::
 ::::
 
-::::{grid-item}
-:::{card} ✿ Code of Conduct ✿
-:link: CODE_OF_CONDUCT
-:link-type: doc
-:class-card: left-aligned
-
-Our code of conduct applies to all members of the pyOpenSci community. And to those participating in pyOpenSci supported events.
-:::
-::::
-
-::::{grid-item}
-:::{card} ✿ Contributing Guide ✿
-:class-card: left-aligned
-:link: CONTRIBUTING
-:link-type: doc
-
-Our contributing guide applicable to all repositories in our pyOpenSci GitHub organization. You can find specific resources for
-local development builds of content in individual pyOpenSci repositories.
-:::
-::::
 
 ::::{grid-item}
 :::{card}  Meeting Archives <i class="fa-solid fa-pencil"></i>

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Learn more about pyOpenSci's:
 
 * [Mission, vision, and values](mission-vision)
 * [Organization and structure](pyos-structure)
-* [Executive council & leadership structure](executive-council)
+* [Executive council & leadership structure](pyos-executive-council)
 :::
 ::::
 

--- a/index.md
+++ b/index.md
@@ -24,7 +24,6 @@ Learn more about pyOpenSci's:
 
 ::::{grid-item}
 :::{card} <i class="fa-solid fa-screwdriver-wrench"></i> Our Organization <i class="fa-solid fa-screwdriver-wrench"></i>
-:link: organization/index
 
 Learn about [how we work](how-we-work) at pyOpenSci.
 
@@ -37,8 +36,6 @@ Learn about [how we work](how-we-work) at pyOpenSci.
 ::::{grid-item}
 :::{card} <i class="fa-solid fa-hand-sparkles"></i> Our Community <i class="fa-solid fa-hand-sparkles"></i>
 :class-card: left-aligned
-:link: community/index
-:link-type: doc
 
 Learn more about the vibrant pyOpenSci community of practice.
 
@@ -61,7 +58,6 @@ Learn more about the vibrant pyOpenSci community of practice.
 ::::{grid-item}
 :::{card}  Meeting Archives <i class="fa-solid fa-pencil"></i>
 :class-card: left-aligned
-:link: reference/index.html
 
 These are notes taken during 2018-2021 - the early meetings when
 we were developing and founding pyOpenSci.

--- a/index.md
+++ b/index.md
@@ -5,7 +5,6 @@ that support pyOpenSci operations.
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/pyopensci/governance?color=purple&display_name=tag&style=plastic)](https://github.com/pyOpenSci/handbook/releases) [![DOI](https://zenodo.org/badge/161679308.svg)](https://zenodo.org/badge/latestdoi/161679308) [![All Contributors](https://img.shields.io/badge/all_contributors-3-blue.svg?style=flat-square)](https://github.com/pyOpenSci/handbook?tab=readme-ov-file#contributors-)
 
-
 :::::{grid} 1 1 2 2
 :class-container: text-center
 :gutter: 3
@@ -41,7 +40,8 @@ Learn more about the vibrant pyOpenSci community of practice.
 
 * [How we use GitHub](github-intro)
 * [About our events](pyos-events)
-* Community platforms that we use which include [Slack](pyos-slack) and [Zenodo](pyos-zenodo).
+* [Translation & internationalization](translation)
+* Community platforms that we use: [Slack](pyos-slack),  [Zenodo](pyos-zenodo), etc.
 
 :::
 ::::
@@ -53,7 +53,6 @@ Learn more about the vibrant pyOpenSci community of practice.
 * Our [Contributing guide](CONTRIBUTING) will help you get oriented to contributing to pyOpenSci.
 :::
 ::::
-
 
 ::::{grid-item}
 :::{card} Meeting Archives <i class="fa-solid fa-pencil"></i>

--- a/index.md
+++ b/index.md
@@ -56,8 +56,9 @@ Learn more about the vibrant pyOpenSci community of practice.
 
 
 ::::{grid-item}
-:::{card}  Meeting Archives <i class="fa-solid fa-pencil"></i>
+:::{card} Meeting Archives <i class="fa-solid fa-pencil"></i>
 :class-card: left-aligned
+:link: reference/index.html
 
 These are notes taken during 2018-2021 - the early meetings when
 we were developing and founding pyOpenSci.

--- a/organization/branding.md
+++ b/organization/branding.md
@@ -1,3 +1,4 @@
+(pyos-brand)=
 # The pyOpenSci brand
 
 The pyOpenSci brand is playful and curious. It integrates a calm, gender-neutral color palette with illustrations and abstract primary shapes that are soft, round, and flowing.

--- a/organization/external-communication.md
+++ b/organization/external-communication.md
@@ -1,3 +1,4 @@
+(external-comms)=
 # External Communication
 
 pyOpenSci uses a multitude of communication platforms to maintain and grow our community. Our external communications fall under the broad categories of:

--- a/organization/how-we-work.md
+++ b/organization/how-we-work.md
@@ -24,6 +24,7 @@ GitHub is public-facing to our entire community.
 
 To learn more about GitHub processes at pyOpenSci, please refer to the [GitHub processes](github-intro) handbook page.
 
+(google-drive)=
 ### Google Drive
 
 [Google Drive](https://drive.google.com/), part of the pyOpenSci Google Workspace, is used to store all internal pyOpenSci documents, spreadsheets, slides, photos, and graphics essential for our operations. Each pyOpenSci staff member has a personal, work-related Google Drive account for individual documents, while shared resources are stored in designated folders on the organizational shared drive.

--- a/organization/how-we-work.md
+++ b/organization/how-we-work.md
@@ -1,3 +1,4 @@
+(how-we-work)=
 # How we work
 
 pyOpenSci uses various platforms to work collaboratively internally and with the broader community, including:

--- a/organization/social-media-blog.md
+++ b/organization/social-media-blog.md
@@ -1,3 +1,4 @@
+(social-platforms)=
 # External Communication & Social Media
 
 pyOpenSci uses several popular social channels and platforms to connect with the

--- a/reference/meeting-notes/executive-council/intro.md
+++ b/reference/meeting-notes/executive-council/intro.md
@@ -1,3 +1,4 @@
+(ec-minutes)=
 # pyOpenSci Executive Council Minutes
 
 :::{toctree}


### PR DESCRIPTION
This PR adds a new page that overviews how the EC works to our guidebook. I also fixed some typos and coordinated content between this page and the main governance page while adding some target links to other pages. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209025198594534
  - https://app.asana.com/0/0/1209001099923590