### PR TITLE
docs: remove references to obsolete PyOS Discourse

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,6 @@ Anyone who participates in a pyOpenSci activity either online or in person is ex
 
 * in GitHub repositories
 * in our Slack channel
-* in our Discourse online forum
 * during in-person events,
 * when representing pyOpenSci in public,
 * or in any event online or in person where pyOpenSci is leading the event.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ for giving credit to contributors for their work.
 Our [peer-review-guide](https://zenodo.org/record/7101778) and [packaging-guide](https://zenodo.org/record/7786869) can be cited using a
 Zenodo DOI. As such, we periodically update authorship for those documents prior to a new release.
 
-Every time we make a release, we will review our `.zenodo` file and contributors for reviews, edits, and other contributions to our content. In many cases, because discussions around content happen in other forums (Discourse, Discord, Slack, and email), we will do our best to capture all contributors.
+Every time we make a release, we will review our `.zenodo` file and contributors for reviews, edits, and other contributions to our content. In many cases, because discussions around content happen in other forums (Discord, Slack, and email), we will do our best to capture all contributors.
 
 Those who have contributed directly to updating the content will be added as authors. Otherwise, you will be added as a contributor. Both categories are listed in the Zenodo citation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ for giving credit to contributors for their work.
 Our [peer-review-guide](https://zenodo.org/record/7101778) and [packaging-guide](https://zenodo.org/record/7786869) can be cited using a
 Zenodo DOI. As such, we periodically update authorship for those documents prior to a new release.
 
-Every time we make a release, we will review our `.zenodo` file and contributors for reviews, edits, and other contributions to our content. In many cases, because discussions around content happen in other forums (Discord, Slack, and email), we will do our best to capture all contributors.
+Every time we make a release, we will review our `.zenodo` file and contributors for reviews, edits, and other contributions to our content. In many cases, because discussions around content happen in other forums (Slack, and email), we will do our best to capture all contributors.
 
 Those who have contributed directly to updating the content will be added as authors. Otherwise, you will be added as a contributor. Both categories are listed in the Zenodo citation.
 

--- a/community/events/sprints.md
+++ b/community/events/sprints.md
@@ -340,9 +340,6 @@ steps to take:
      [repositories on GitHub](https://github.com/pyopensci).
 :::{todo}
 
-* Discourse?
-:::
-
 4. **Stay Connected**:
    * **Upcoming Events**: Inform participants about upcoming sprints, webinars,
  workshops, or any other events they might be interested in.

--- a/governance/structure.md
+++ b/governance/structure.md
@@ -72,7 +72,7 @@ organization. This position will:
 * Create strategic communication plans
 * Write and oversee blog writing
 * Manage website content
-* Support communications within our online communication platforms (e.g. Slack, Discourse, Discord etc.)
+* Support communications within our online communication platforms (e.g. Slack, Discord, GitHub Discussions, etc.)
 
 The Community Manager is a paid position in the pyOpenSci organization.
 :::

--- a/governance/structure.md
+++ b/governance/structure.md
@@ -72,7 +72,7 @@ organization. This position will:
 * Create strategic communication plans
 * Write and oversee blog writing
 * Manage website content
-* Support communications within our online communication platforms (e.g. Slack, Discord, GitHub Discussions, etc.)
+* Support communications within our online communication platforms (e.g. Slack, GitHub Discussions, etc.)
 
 The Community Manager is a paid position in the pyOpenSci organization.
 :::

--- a/organization/social-media-blog.md
+++ b/organization/social-media-blog.md
@@ -118,15 +118,14 @@ For more information on how pyOpenSci uses GitHub, please refer to the [GitHub s
 
 ### Promoting blog posts
 
-All blog posts should be promoted, regardless of whether or not they were written by a guest or a pyOpenSci employee! For promotion, coordinate with the Community Manager to ensure that there’s a tailored message for each of the following platforms:
+All blog posts should be promoted, regardless of whether or not they were written by a guest or a pyOpenSci employee. For promotion, coordinate with the Community Manager to ensure that there’s a tailored message for each of the following platforms:
 
 * Slack
-* Discourse
 * BlueSky
 * LinkedIn
 * Fosstodon
 
-In addition to pyOpenSci social outreach, we monitor social media for any personal posts that authors have created. To promote these posts, we will repost.
+In addition to pyOpenSci own social media outreach, we monitor social media for any personal posts that authors have created. To promote these posts, we will repost.
 
 ### Blog post tone
 
@@ -158,7 +157,7 @@ We publish two newsletters:
 The weekly LinkedIn newsletter has three main categories:
 
 * The monthly round-up edition, sharing and celebrating pyOpenSci and community wins over the past month
-* A monthly "Community News" edition, which shares conversations, discussions, and decisions that have taken place in Slack as well as on Discourse and GitHub, that are relevant to the broader community
+* A monthly "Community News" edition, which shares conversations, discussions, and decisions that have taken place in Slack as well as on GitHub, that are relevant to the broader community
 * Re-posts of interesting pyOpenSci blog posts
 
 These posts are all structured as blog posts, using appropriate heading and subheading formats within LinkedIn. In fact, all of our newsletters are first published on the pyOpenSci blog, and should follow the same tone and format.


### PR DESCRIPTION
Remove references to obsolete PyOS Discourse.
Minor edits to the related content.