### PR TITLE
Update peer review guide URL

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -71,7 +71,7 @@ html_theme_options = {
             "name": "Packaging Guide",
         },
         {
-            "url": "https://pyopensci.org/peer-review-guide",
+            "url": "https://www.pyopensci.org/software-peer-review/",
             "name": "Peer Review Guide",
         },
     ],


### PR DESCRIPTION
I encountered a broken link in the "More" dropdown on <https://www.pyopensci.org/handbook/>

This PR updates the URL in `conf.py` to what I think is the correct target.